### PR TITLE
Changes to build process for 2.24

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - git submodule update --init --recursive
 install: true
 script:
-    - mvn -Ddocbkx.fopLogLevel=ERROR -Denforcer.fail=false -q package
+    - bash ./travis-build.sh
 after_success:
     - bash ./.utility/deploy.sh
 jdk:

--- a/.utility/deploy.sh
+++ b/.utility/deploy.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ] \
+[ "$TRAVIS_BRANCH"== "master" ]; then
     set -e # exit with nonzero exit code if anything fails
 
     cd ${HOME}

--- a/.utility/deploy.sh
+++ b/.utility/deploy.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+BRANCH_REGEX="2.2[0-9]|master"
+
 if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ] \
-[ "$TRAVIS_BRANCH"== "master" ]; then
+ && [[ "$TRAVIS_BRANCH" =~ $BRANCH_REGEX ]]; then
     set -e # exit with nonzero exit code if anything fails
 
     cd ${HOME}

--- a/.utility/index.html
+++ b/.utility/index.html
@@ -86,6 +86,49 @@
         </tr>
     </tbody>
     </table>
+<h3>DHIS 2.24 Documentation (English)</h3>
+    <table class="table table-bordered table-striped">
+        <thead>
+        <tr>
+            <th>Package</th>
+            <th>PDF</th>
+            <th>HTML</th>
+            <th>HTML single page</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>User Documentation</td>
+            <td><a href="2.24/en/user/dhis2_user_manual_en.pdf">PDF</a></td>
+            <td><a href="2.24/en/user/html/dhis2_user_manual_en.html">HTML</a></td>
+            <td><a href="2.24/en/user/html/dhis2_user_manual_en_full.html">HTML single page</a></td>
+        </tr>
+        <tr>
+            <td>Implementation Guide</td>
+            <td><a href="2.24/en/implementer/dhis2_implementation_guide_en.pdf">PDF</a></td>
+            <td><a href="2.24/en/implementer/html/dhis2_implementation_guide_en.html">HTML</a></td>
+            <td><a href="2.24/en/implementer/html/dhis2_implementation_guide_en_full.html">HTML single page</a></td>
+        </tr>
+        <tr>
+            <td>End user manual</td>
+            <td><a href="2.24/en/end-user/dhis2_end_user_manual.pdf">PDF</a></td>
+            <td><a href="2.24/en/end-user/html/dhis2_end_user_manual.html">HTML</a></td>
+            <td><a href="2.24/en/end-user/html/dhis2_end_user_manual_full.html">HTML single page</a></td>
+        </tr>
+        <tr>
+            <td>Android Apps manual</td>
+            <td><a href="2.24/en/android/dhis2_android_user_man.pdf">PDF</a></td>
+            <td><a href="2.24/en/android/html/dhis2_android_user_man.html">HTML</a></td>
+            <td><a href="2.24/en/android/html/dhis2_android_user_man_full.html">HTML single page</a></td>
+        </tr>
+        <tr>
+            <td>Developer guide</td>
+            <td><a href="2.24/en/developer/dhis2_developer_manual.pdf">PDF</a></td>
+            <td><a href="2.24/en/developer/html/dhis2_developer_manual.html">HTML</a></td>
+            <td><a href="2.24/en/developer/html/dhis2_developer_manual_full.html">HTML single page</a></td>
+        </tr>
+    </tbody>
+    </table>
       <h3>DHIS 2.23 Documentation (English)</h3>
     <table class="table table-bordered table-striped">
         <thead>
@@ -169,51 +212,6 @@
             <td><a href="2.22/en/developer/dhis2_developer_manual.pdf">PDF</a></td>
             <td><a href="2.22/en/developer/html/dhis2_developer_manual.html">HTML</a></td>
             <td><a href="2.22/en/developer/html/dhis2_developer_manual_full.html">HTML single page</a></td>
-        </tr>
-    </tbody>
-    </table>
-
- 
-    <h3>DHIS 2.21 Documentation (English)</h3>
-    <table class="table table-bordered table-striped">
-        <thead>
-        <tr>
-            <th>Package</th>
-            <th>PDF</th>
-            <th>HTML</th>
-            <th>HTML single page</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>User Documentation</td>
-            <td><a href="2.21/en/user/dhis2_user_manual_en.pdf">PDF</a></td>
-            <td><a href="2.21/en/user/html/dhis2_user_manual_en.html">HTML</a></td>
-            <td><a href="2.21/en/user/html/dhis2_user_manual_en_full.html">HTML single page</a></td>
-        </tr>
-        <tr>
-            <td>Implementation Guide</td>
-            <td><a href="2.21/en/implementer/dhis2_implementation_guide_en.pdf">PDF</a></td>
-            <td><a href="2.21/en/implementer/html/dhis2_implementation_guide_en.html">HTML</a></td>
-            <td><a href="2.21/en/implementer/html/dhis2_implementation_guide_en_full.html">HTML single page</a></td>
-        </tr>
-        <tr>
-            <td>End user manual</td>
-            <td><a href="2.21/en/end-user/dhis2_end_user_manual.pdf">PDF</a></td>
-            <td><a href="2.21/en/end-user/html/dhis2_end_user_manual.html">HTML</a></td>
-            <td><a href="2.21/en/end-user/html/dhis2_end_user_manual_full.html">HTML single page</a></td>
-        </tr>
-        <tr>
-            <td>Android Apps manual</td>
-            <td><a href="2.21/en/android/dhis2_android_user_man.pdf">PDF</a></td>
-            <td><a href="2.21/en/android/html/dhis2_android_user_man.html">HTML</a></td>
-            <td><a href="2.21/en/android/html/dhis2_android_user_man_full.html">HTML single page</a></td>
-        </tr>
-        <tr>
-            <td>Developer guide</td>
-            <td><a href="2.21/en/developer/dhis2_developer_manual.pdf">PDF</a></td>
-            <td><a href="2.21/en/developer/html/dhis2_developer_manual.html">HTML</a></td>
-            <td><a href="2.21/en/developer/html/dhis2_developer_manual_full.html">HTML single page</a></td>
         </tr>
     </tbody>
     </table>

--- a/pom-short.xml
+++ b/pom-short.xml
@@ -1,0 +1,175 @@
+﻿<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.hisp.dhis</groupId>
+	<artifactId>dhis-documentation-docbook</artifactId>
+	<name>DHIS2 Documentation</name>
+	<version>2.24</version>
+	<description>DHIS 2 Documentation</description>
+	<packaging>pom</packaging>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>docbkx.snapshots</id>
+			<name>Maven Plugin Snapshots</name>
+			<url>http://docbkx-tools.sourceforge.net/snapshots/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
+			<id>docbook-utils</id>
+			<name>DocBook Utils</name>
+			<url>http://docbook-utils.sourceforge.net/maven2</url>
+			<layout>default</layout>
+			<releases>
+				<enabled>true</enabled>
+				<updatePolicy>daily</updatePolicy>
+				<checksumPolicy>warn</checksumPolicy>
+			</releases>
+		</pluginRepository>
+	</pluginRepositories>
+	<properties>
+		<docbkx.plugin.version>2.0.17</docbkx.plugin.version>
+		<docbook.source>${project.basedir}/src/docbkx</docbook.source>
+		<docbook.target>${project.basedir}/target/site</docbook.target>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>1.1.1</version>
+				<executions>
+					<execution>
+						<id>enforce</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>[3.0.5,)</version>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>[1.6,)</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!--This section dynamically builds the build.properties which is replaced inside the document preface -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>revision</id>
+						<phase>package</phase>
+						<configuration>
+							<tasks>
+								<tstamp>
+									<format property="now" pattern="yyyy-MM-dd HH:mm:ss"/>
+								</tstamp>
+								<exec executable="git" outputproperty="revision" failifexecutionfails="false">
+									<arg line="rev-list --count HEAD"/>
+								</exec>
+								<echo file="${project.basedir}/src/docbkx/build.properties" message="&lt;revhistory  xmlns=&apos;http://docbook.org/ns/docbook&apos;&gt;&lt;revision&gt;&lt;revnumber&gt;${revision}&lt;/revnumber&gt;&lt;date&gt;${now}&lt;/date&gt;&lt;revremark&gt;Version ${project.version}&lt;/revremark&gt;&lt;/revision&gt;&lt;/revhistory&gt;"/>
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>submodules</id>
+						<phase>package</phase>
+						<configuration>
+							<tasks>
+								<exec executable="git" failifexecutionfails="true">
+									<arg line="submodule update --init --recursive"/>
+								</exec>
+							</tasks>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.agilejava.docbkx</groupId>
+				<artifactId>docbkx-maven-plugin</artifactId>
+				<version>${docbkx.plugin.version}</version>
+				<configuration>
+					<xincludeSupported>true</xincludeSupported>
+					<bodyFontFamily>DejaVu Sans</bodyFontFamily>
+					<fonts>
+						<font>
+							<name>DejaVu Sans</name>
+							<style>normal</style>
+							<weight>normal</weight>
+							<embedFile>${project.basedir}/src/fonts/DejaVuSans.ttf</embedFile>
+							<metricsFile>${project.basedir}/target/fonts/DejaVuSans-metrics.xml</metricsFile>
+						</font>
+					</fonts>
+				</configuration>
+				<executions>
+					<!-- Single page HTML -->
+					<execution>
+						<id>html-docs-en</id>
+						<phase>package</phase>
+						<goals>
+							<goal>generate-html</goal>
+						</goals>
+						<configuration>
+							<admonGraphics>1</admonGraphics>
+							<admonGraphicsPath>resources/images/admon/</admonGraphicsPath>
+							<htmlStylesheet>resources/css/docbook_bsd.css</htmlStylesheet>
+							<glossaryCollection>resources/glossary_en.xml</glossaryCollection>
+							<sectionAutolabel>1</sectionAutolabel>
+							<sectionLabelIncludesComponentLabel>1</sectionLabelIncludesComponentLabel>
+							<chunkedOutput>false</chunkedOutput>
+							<includes>dhis2_user_manual_en.xml,dhis2_android_user_man.xml,dhis2_end_user_manual.xml,dhis2_implementation_guide_en.xml,ccei_user_manual_en.xml,dhis2_developer_manual.xml</includes>
+							<sourceDirectory>${docbook.source}/en/</sourceDirectory>
+						</configuration>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>net.sf.docbook</groupId>
+						<artifactId>docbook-xml</artifactId>
+						<version>5.0-all</version>
+						<classifier>resources</classifier>
+						<type>zip</type>
+						<scope>runtime</scope>
+					</dependency>
+					<dependency>
+						<groupId>net.sf.offo</groupId>
+						<artifactId>fop-hyph</artifactId>
+						<version>1.2</version>
+						<scope>runtime</scope>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>com.agilejava.docbkx</groupId>
+				<artifactId>docbkx-fop-support</artifactId>
+				<version>${docbkx.plugin.version}</version>
+				<executions>
+					<execution>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<ansi>false</ansi>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -10,3 +10,5 @@ if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" ==
     mvn -f pom-short.xml -Ddocbkx.fopLogLevel=ERROR -Denforcer.fail=false  package
   fi
 fi 
+
+exit $?

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
+ ["TRAVIS_BRANCH" == "master" ]; then
+    set -e # exit with nonzero exit code if anything fails
+    mvn -Ddocbkx.fopLogLevel= -Denforcer.fail=false -q package
+fi
+   
+if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ] && \ 
+ [ "$TRAVIS_BRANCH" != "master" ]; then
+    set -e # exit with nonzero exit code if anything fails
+    mvn -f pom-short.xml -Ddocbkx.fopLogLevel=ERROR -Denforcer.fail=false  package
+fi 

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
+BRANCH_REGEX="2.2[0-9]|master"
 
-if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ] && \
- ["TRAVIS_BRANCH" == "master" ]; then
-    set -e # exit with nonzero exit code if anything fails
-    mvn -Ddocbkx.fopLogLevel= -Denforcer.fail=false -q package
-fi
-   
-if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ] && \ 
- [ "$TRAVIS_BRANCH" != "master" ]; then
-    set -e # exit with nonzero exit code if anything fails
+set -e # exit with nonzero exit code if anything fails
+
+if [ "$TRAVIS_REPO_SLUG" == "dhis2/dhis2-docs" ]  && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+  if [[ "$TRAVIS_BRANCH" =~ $BRANCH_REGEX ]]; then
+    mvn -Ddocbkx.fopLogLevel=ERROR -Denforcer.fail=false -q package
+  else
     mvn -f pom-short.xml -Ddocbkx.fopLogLevel=ERROR -Denforcer.fail=false  package
+  fi
 fi 


### PR DESCRIPTION
@ceciliapersson , this should update the build process and GitHub pages for the 2.24 build. v 2.24,2.23 and 2.21 will be kept on the GitHub pages. 2.21 will be deprecated  in line with supporting the last three releases, but this can be changed if needed. 

@larshelge FYI