### PR TITLE
Cluster config changes

### DIFF
--- a/src/docbkx/en/content/implementer/installation.xml
+++ b/src/docbkx/en/content/implementer/installation.xml
@@ -600,14 +600,14 @@ read3.connection.url = jdbc:postgresql://127.0.0.13/dbread3</screen></para>
         2 instance one must specify the public <emphasis>hostname</emphasis> as well as the
         hostnames of the other instances participating in the cluster. </para>
       <para>The hostname of the server is specified using the
-          <emphasis>cluster.instance.hostname</emphasis> configuration property. Additional servers
+          <emphasis>cluster.hostname</emphasis> configuration property. Additional servers
         which participate in the cluster are specified using the <emphasis>cluster.members</emphasis> configuration property. The property expects a list of comma separated values where each value is of the format  <emphasis>host:port</emphasis>.
        </para>
       <para>The hostname must be visible to the participating servers on the network for the
         clustering to work. You might have to allow incoming and outgoing connections on port 4001
         (or whichever port number is configured) in the firewall.</para>
       <para>The port number of the server is specified using the<emphasis>
-          cluster.instance.cache.port</emphasis> configuration property. Specifying the port number
+          cluster.cache.port</emphasis> configuration property. Specifying the port number
         is typically only useful when you have multiple cluster instances on the same server /
         virtual machine. When running cluster instances on separate servers / virtual machines it is
         often appropriate to use the default port number and omit this configuration
@@ -618,10 +618,10 @@ read3.connection.url = jdbc:postgresql://127.0.0.13/dbread3</screen></para>
         <emphasis>dhis.conf</emphasis>:<screen># Cluster configuration for server A
 
 # Hostname for this web server
-cluster.instance.hostname = 193.157.199.131
+cluster.hostname = 193.157.199.131
 
 # Port for cache listener, can be omitted
-cluster.instance.cache.port = 4001
+cluster.cache.port = 4001
 
 # List of Host:port participating in the cluster
 cluster.members = 193.157.199.132:4001
@@ -633,7 +633,7 @@ cluster.members = 193.157.199.132:4001
         omitted):<screen># Cluster configuration for server B
 
 # Hostname for this web server
-cluster.instance.hostname = 193.157.199.132
+cluster.hostname = 193.157.199.132
 
 # List of servers participating in cluster
 cluster.members = 193.157.199.131:4001</screen></para>

--- a/src/docbkx/en/content/implementer/installation.xml
+++ b/src/docbkx/en/content/implementer/installation.xml
@@ -598,50 +598,45 @@ read3.connection.url = jdbc:postgresql://127.0.0.13/dbread3</screen></para>
       <title>Cluster configuration</title>
       <para>A DHIS 2 cluster setup is based on manual configuration of each instance. For each DHIS
         2 instance one must specify the public <emphasis>hostname</emphasis> as well as the
-        hostnames of the other instances participating in the cluster. You can optionally specify
-        the <emphasis>port</emphasis> number for which each instance should listen for cache
-        updates. The default port number is 4001.</para>
+        hostnames of the other instances participating in the cluster. </para>
       <para>The hostname of the server is specified using the
-          <emphasis>cluster.instance0.hostname</emphasis> configuration property. Additional servers
-        which participate in the cluster are specified using properties on the format
-          <emphasis>cluster.instanceN.hostname</emphasis>, where N refers to the cluster instance
-        number. You can specify up to 4 cluster instances in a configuration file, giving a maximum
-        cluster size of 5 instances. N is a number between 1 and 4.</para>
+          <emphasis>cluster.instance.hostname</emphasis> configuration property. Additional servers
+        which participate in the cluster are specified using the <emphasis>cluster.members</emphasis> configuration property. The property expects a list of comma separated values where each value is of the format  <emphasis>host:port</emphasis>.
+       </para>
       <para>The hostname must be visible to the participating servers on the network for the
         clustering to work. You might have to allow incoming and outgoing connections on port 4001
         (or whichever port number is configured) in the firewall.</para>
       <para>The port number of the server is specified using the<emphasis>
-          cluster.instance0.cache.port</emphasis> configuration property. Specifying the port number
+          cluster.instance.cache.port</emphasis> configuration property. Specifying the port number
         is typically only useful when you have multiple cluster instances on the same server /
         virtual machine. When running cluster instances on separate servers / virtual machines it is
         often appropriate to use the default port number and omit this configuration
         property.</para>
       <para>An example setup for a cluster of two web servers is described below. For
-          <emphasis>server A</emphasis> availabe at hostname <emphasis>193.157.199.131</emphasis>
+          <emphasis>server A</emphasis> available at hostname <emphasis>193.157.199.131</emphasis>
         the following can be specified in
         <emphasis>dhis.conf</emphasis>:<screen># Cluster configuration for server A
 
 # Hostname for this web server
-cluster.instance0.hostname = 193.157.199.131
+cluster.instance.hostname = 193.157.199.131
 
 # Port for cache listener, can be omitted
-cluster.instance0.cache.port = 4001
+cluster.instance.cache.port = 4001
 
-# Hostname for web server B participating in cluster
-cluster.instance1.hostname = 193.157.199.132
+# List of Host:port participating in the cluster
+cluster.members = 193.157.199.132:4001
 
-# Port for cache listener on web server B, can be omitted
-cluster.instance1.cache.port = 4001</screen></para>
+</screen></para>
       <para>For <emphasis>server B</emphasis> available at hostname
           <emphasis>193.157.199.132</emphasis> the following can be specified in
           <emphasis>dhis.conf</emphasis> (notice how port configuration is
         omitted):<screen># Cluster configuration for server B
 
 # Hostname for this web server
-cluster.instance0.hostname = 193.157.199.132
+cluster.instance.hostname = 193.157.199.132
 
-# Hostname for web server A participating in cluster
-cluster.instance1.hostname = 193.157.199.131</screen></para>
+# List of servers participating in cluster
+cluster.members = 193.157.199.131:4001</screen></para>
       <para>You must restart each Tomcat instance to make the changes take effect. The two instances
         have now been made aware of each other and DHIS 2 will ensure that their caches are kept in
         sync.</para>


### PR DESCRIPTION
Changed cluster config property to support comma separated multiple HOST:PORT values for configuring the cluster members. Changed 'cluster.instance.hostname' to 'cluster.hostname' and 'cluster.instance.cache.port' to 'cluster.cache.port'