### PR TITLE
Added documentation for pivot and event reports size warning

### DIFF
--- a/src/docbkx/en/content/analysis/pivot_tables.xml
+++ b/src/docbkx/en/content/analysis/pivot_tables.xml
@@ -63,7 +63,9 @@ Revise phrase to &quot;A pivot table arranges data...&quot; = correct?"?>can
           <listitem>
             <para>A pivot table can't contain more than the maximum number of analytic records which
               have been specified in the system settings. The maximum number of records could also
-              be constrained by the maximum RAM which is available to your browser. Consider making
+              be constrained by the maximum RAM which is available to your browser. You will be prompted
+              with a warning if your requested table exceeds a particular size. From this prompt,
+              you can either cancel the request or continue building the table. Consider making
               smaller tables instead of one table which displays all of your data elements and
               indicators together.</para>
           </listitem>

--- a/src/docbkx/en/content/events/event_reports.xml
+++ b/src/docbkx/en/content/events/event_reports.xml
@@ -28,7 +28,11 @@
           you can use the <emphasis role="bold">Event Reports</emphasis> app to create pivot tables
           with aggregated numbers of events. An event report is always based on a program. You can
           do analysis based on a range of dimensions. Each dimension can have a corresponding
-          filter. Dimensions can be selected from the left-side menu.</para>
+          filter. Dimensions can be selected from the left-side menu. Similar to the pivot tables app,
+          aggregated event reports may be limited by the amount of RAM accessible by the browser.
+          If your requested table exceeds a set size, you will recieve a warning prompt asking whether
+          or not you want to continue.
+          </para>
       </listitem>
       <listitem>
         <para>Individual event reports: Lists of events</para>


### PR DESCRIPTION
Added some documentation regarding the warning popup  which appears when creating large pivot tables / aggregated event reports.