### PR TITLE
fix(settings-app): hide periods in analysis app

### DIFF
--- a/src/commonmark/en/content/user/system-settings.md
+++ b/src/commonmark/en/content/user/system-settings.md
@@ -55,22 +55,6 @@
 <td><p>Setting this value will determine which relative period is selected as the default in the analytics apps.</p></td>
 </tr>
 <tr class="odd">
-    <td><p><strong>Hide daily periods</strong></p></td>
-    <td><p>Hide daily periods in the analysis tools</p></td>
-</tr>
-<tr class="even">
-    <td><p><strong>Hide weekly periods</strong></p></td>
-    <td><p>Hide weekly periods in the analysis tools</p></td>
-</tr>
-<tr class="odd">
-    <td><p><strong>Hide monthly periods</strong></p></td>
-    <td><p>Hide monthly periods in the analysis tools</p></td>
-</tr>
-<tr class="even">
-    <td><p><strong>Hide bimonthly periods</strong></p></td>
-    <td><p>Hide bimonthly periods in the analysis tools</p></td>
-</tr>
-<tr class="odd">
 <td><p><strong>Feedback recipients</strong></p></td>
 <td><p>Defines a user group where the members will receive all messages sent via the feedback function in the <strong>Dashboard</strong> app.</p>
 <p>This will typically be members of the super user team who are able to support and answer questions coming from end-users.</p></td>
@@ -125,6 +109,22 @@
 <td><p><strong>Default relative period for analysis</strong></p></td>
 <td><p>Defines the relative period to use by default in analytics app: <strong>Data Visualizer</strong>, <strong>Event Reports</strong>, <strong>Event Visualizer</strong>, <strong>GIS</strong> and <strong>Pivot Table</strong> apps. The relative period will be automatically selected when you open these apps.</p>
 <p>Recommended setting: the most commonly used relative period among your users.</p></td>
+</tr>
+<tr class="even">
+    <td><p><strong>Hide daily periods</strong></p></td>
+    <td><p>Hide daily periods in the analysis tools</p></td>
+</tr>
+<tr class="odd">
+    <td><p><strong>Hide weekly periods</strong></p></td>
+    <td><p>Hide weekly periods in the analysis tools</p></td>
+</tr>
+<tr class="even">
+    <td><p><strong>Hide monthly periods</strong></p></td>
+    <td><p>Hide monthly periods in the analysis tools</p></td>
+</tr>
+<tr class="odd">
+    <td><p><strong>Hide bimonthly periods</strong></p></td>
+    <td><p>Hide bimonthly periods in the analysis tools</p></td>
 </tr>
 <tr class="even">
 <td><strong>Financial year relative start month</strong></td>

--- a/src/commonmark/en/content/user/system-settings.md
+++ b/src/commonmark/en/content/user/system-settings.md
@@ -55,6 +55,22 @@
 <td><p>Setting this value will determine which relative period is selected as the default in the analytics apps.</p></td>
 </tr>
 <tr class="odd">
+    <td><p><strong>Hide daily periods</strong></p></td>
+    <td><p>Hide daily periods in the analysis tools</p></td>
+</tr>
+<tr class="even">
+    <td><p><strong>Hide weekly periods</strong></p></td>
+    <td><p>Hide weekly periods in the analysis tools</p></td>
+</tr>
+<tr class="odd">
+    <td><p><strong>Hide monthly periods</strong></p></td>
+    <td><p>Hide monthly periods in the analysis tools</p></td>
+</tr>
+<tr class="even">
+    <td><p><strong>Hide bimonthly periods</strong></p></td>
+    <td><p>Hide bimonthly periods in the analysis tools</p></td>
+</tr>
+<tr class="odd">
 <td><p><strong>Feedback recipients</strong></p></td>
 <td><p>Defines a user group where the members will receive all messages sent via the feedback function in the <strong>Dashboard</strong> app.</p>
 <p>This will typically be members of the super user team who are able to support and answer questions coming from end-users.</p></td>


### PR DESCRIPTION
Added explanation for 4 new fields to the docs:
ANALYTICS_HIDE_DAILY_PERIODS
ANALYTICS_HIDE_WEEKLY_PERIODS
ANALYTICS_HIDE_MONTHLY_PERIODS
ANALYTICS_HIDE_BIMONTHLY_PERIODS