### PR TITLE
Update dhis2_implementation_guide_INDEX.md

### DIFF
--- a/src/commonmark/en/dhis2_implementation_guide_INDEX.md
+++ b/src/commonmark/en/dhis2_implementation_guide_INDEX.md
@@ -9,7 +9,6 @@ title: 'DHIS 2 Implementer guide'
 !INCLUDE "content/implementation/setting-up-a-new-database.md"
 !INCLUDE "content/implementation/deployment-strategies.md"
 !INCLUDE "content/implementation/dhis2-as-data-warehouse.md"
-!INCLUDE "content/implementation/end-user-training.md"
 !INCLUDE "content/implementation/integration-concepts.md"
 !INCLUDE "content/implementation/offline-data-entry.md"
 !INCLUDE "content/implementation/installation.md"


### PR DESCRIPTION
Temporarily removed the chapter on end user training until we have an updated version of that content. 