### PR TITLE
update: interpretations sort order [DHIS2-4008]

### DIFF
--- a/src/commonmark/en/content/user/managing-dashboards.md
+++ b/src/commonmark/en/content/user/managing-dashboards.md
@@ -242,7 +242,8 @@ limited set of smilies is supported and can be used by typing one of the
 following character combinations: :) :-) :( :-( :+1 :-1. URLs are
 automatically detected and converted into a clickable link.
 
-Interpretations and replies sorted by date ascending, with the oldest shown on top.
+Interpretations are sorted by date descending, with the most recent shown on top.
+Interpretation replies are sorted by date ascending, with the oldest shown on top.
 
 ![](resources/images/dashboard/dashboard-interpretations.png)
 

--- a/src/commonmark/en/content/user/managing-dashboards.md
+++ b/src/commonmark/en/content/user/managing-dashboards.md
@@ -234,13 +234,14 @@ interpretation, and add your own interpretation. You can edit, share or delete
 your own interpretations and replies, and if you have moderator access,
 you can delete others’ interpretations.
 
-It is possible to format the text with **bold**, *italic* by using the
-Markdown style markers \* and \_ for **bold** and *italic* respectively.
-New interpretations have a toolbar in its text field for adding rich text.
-Keyboard shortcuts are also available: Ctrl/Cmd + B and Ctrl/Cmd + I. A
-limited set of smilies is supported and can be used by typing one of the
-following character combinations: :) :-) :( :-( :+1 :-1. URLs are
-automatically detected and converted into a clickable link.
+It is possible to format the description field, and interpretations 
+with **bold**, *italic* by using the Markdown style markers \* and \_ 
+for **bold** and *italic* respectively. The text field for writing new
+interpretations have a toolbar for adding rich text. Keyboard shortcuts
+are also available: Ctrl/Cmd + B and Ctrl/Cmd + I. A limited set of
+smilies is supported and can be used by typing one of the following
+character combinations: :) :-) :( :-( :+1 :-1. URLs are automatically
+detected and converted into a clickable link.
 
 Interpretations are sorted by date descending, with the most recent shown on top.
 Interpretation replies are sorted by date ascending, with the oldest shown on top.


### PR DESCRIPTION
Ticket [DHIS2-5472](https://jira.dhis2.org/browse/DHIS2-5472) and [DHIS2-4008](https://jira.dhis2.org/browse/DHIS2-4008) have different definition of how interpretations should be sorted.

We agreed to follow DHIS2-4008 per PSI's original request (Sorting interpretations with recent at the top, and replies with recent at the bottom).