### PR TITLE
docs: Update default merge mode on metadata import

### DIFF
--- a/src/commonmark/en/content/developer/web-api.md
+++ b/src/commonmark/en/content/developer/web-api.md
@@ -1748,7 +1748,7 @@ exporter. The various parameters are listed below.
 </tr>
 <tr class="odd">
 <td>mergeMode</td>
-<td>MERGE, REPLACE</td>
+<td>REPLACE, MERGE</td>
 <td>Sets the merge mode, when doing updates we have two ways of merging the old object with the new one, <strong>MERGE</strong> mode will only overwrite the old property if the new one is not-null, for <strong>REPLACE</strong> mode all properties are overwritten regardless of null or not.</td>
 </tr>
 <tr class="even">


### PR DESCRIPTION
The default value is actually REPLACE and it could lead to confusion. You can test it through a POST call to the ```/metadata``` endpoint in the importParams response.

See: https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-dxf2/src/main/java/org/hisp/dhis/dxf2/metadata/MetadataImportParams.java#L106

Feel free to re-order the description column if you see fit!