### PR TITLE
fix(user-app): corrected & emphasised user invite prerequisites section

### DIFF
--- a/src/commonmark/en/content/user/manage-users-user-roles-and-user-groups.md
+++ b/src/commonmark/en/content/user/manage-users-user-roles-and-user-groups.md
@@ -246,7 +246,8 @@ with the user name and password that you provide.<br/><br/>
 Choose this option if you want to send an invitation by email to the
 user. Then she/he must return to DHIS2 and finish setting up their user
 account. The account that the user finishes setting up will be limited
-according to how you configure the account.<br/>
+according to how you configure the account.
+
 > **Note**
 >
 > In order to use this feature the system should have a valid email 

--- a/src/commonmark/en/content/user/manage-users-user-roles-and-user-groups.md
+++ b/src/commonmark/en/content/user/manage-users-user-roles-and-user-groups.md
@@ -246,9 +246,13 @@ with the user name and password that you provide.<br/><br/>
 Choose this option if you want to send an invitation by email to the
 user. Then she/he must return to DHIS2 and finish setting up their user
 account. The account that the user finishes setting up will be limited
-according to how you configure the account.<br/><br/>
-In order to use this feature "Enable email message notifications" in
-SystemSettings -\> Messaging should be checked.<br/><br/>
+according to how you configure the account.<br/>
+> **Note**
+>
+> In order to use this feature the system should have a valid email 
+> configuration in SystemSettings -\> Email
+
+
 Enter the email address to which the invitation should be sent. If you
 want to, you may also enter the user name that the account will have. If
 you leave the user name empty, then the user may choose their own user


### PR DESCRIPTION
While @Mohammer5 and I were discussing a reproduction path for issue DHIS2-1439 we realised that the current documentation for inviting users is wrong:
- It is not required to have the "Enable email message notifications" setting enabled
- All that is required, is to have a working email configuration

I've corrected this and also placed it in a grey box to give this point a bit more emphasis, as it is something that has caused confusion in the past too.