### PR TITLE
feat: Include underscore character in object filter

### DIFF
--- a/src/commonmark/en/content/developer/web-api.md
+++ b/src/commonmark/en/content/developer/web-api.md
@@ -993,6 +993,12 @@ associated objects or collection of objects, are supported as well.
 </tbody>
 </table>
 
+When using the "like" and "ilike" operators you can use the _ character (underscore) to match one single character.
+
+Get options with name "Q0_1" (matches to "Q011", "Q021", "Q031", etc.):
+
+    /api/28/options.json?filter=name:ilike:Q0_1
+
 Operators will be applied as logical **and** query, if you need a **or**
 query, you can have a look at our *in* filter (also have a look at the
 section below). The filtering mechanism allows for recursion. See below


### PR DESCRIPTION
I did not find any relevant part in the API docs about this "feature".

Even though it is not a DHIS2 feature we are passing down the query to the SQL:

- https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java#L230

I am not sure if you want this documented somehow but it is an useful feature that right now is hidden.

As of the example, I did not find any relevant results in ``dataElements`` collection so I used the options endpoint. Feel free to rewrite this part as you feel fit.

However full support for SQL matching is not included (adding the ``%`` operator breaks the filtering badly for example). This is something that should be fixed in the core as part of the ``parseFilterOperator`` helper function.

Also another interesting part that could be included in the docs is how to escape this behavior:

```
/api/28/dataElements.json?filter=code:$ilike:D_\_1&fields=id,name,code
```

Note: In https://play.dhis2.org this does not work because it returns error 400 in the nginx when it finds the escape character.

I guess a JIRA ticket should be opened for the core team to take a look into the weird scenarios that could happen using the ``filter`` operation.