### PR TITLE
fix: prevent double backslash in image paths

### DIFF
--- a/tools/python/markdown-pp-master/MarkdownPP/Modules/Include.py
+++ b/tools/python/markdown-pp-master/MarkdownPP/Modules/Include.py
@@ -89,7 +89,7 @@ class Include(Module):
                 if not image:
                     image = self.simpleimagepath.search(line)
                 if image:
-                    data[linenum] = line.replace("resources/images","resources/images/"+dirname)
+                    data[linenum] = line.replace("resources/images","resources/images/"+dirname).replace('//','/')
                     # print(line)
 
                 if shift:


### PR DESCRIPTION
Double backslash in path prevents images from displaying when hosting on 
Amazon S3