### PR TITLE
docs: Update dhis2_android_capture_app_INDEX.md

### DIFF
--- a/src/commonmark/en/dhis2_android_capture_app_INDEX.md
+++ b/src/commonmark/en/dhis2_android_capture_app_INDEX.md
@@ -2,5 +2,5 @@
 title: 'DHIS 2 configuration guide for the Android capture app'
 ---
 <!--DHIS2-SECTION-ID:index-->
-
+!INCLUDE "content/common/about-this-guide.md"
 !SUBMODULE "dhis2-android-capture-app" "master" "docs/src/commonmark/en/dhis2_android_capture_app_INDEX.md"


### PR DESCRIPTION
Added the line to use the about-this-guide from local repository instead of remote so it is aligned with all the other guides.