### PR TITLE
docs: Add Android Implementation guideline

### DIFF
--- a/src/commonmark/en/dhis2_android_implementation_guideline_INDEX.md
+++ b/src/commonmark/en/dhis2_android_implementation_guideline_INDEX.md
@@ -1,6 +1,1 @@
----
-title: 'DHIS 2 configuration guide for the Android capture app'
----
-<!--DHIS2-SECTION-ID:index-->
-
 !SUBMODULE "dhis2-android-capture-app" "master" "docs/src/commonmark/en/dhis2_android_implementation_guideline_INDEX.md"

--- a/src/commonmark/en/dhis2_android_implementation_guidelines_INDEX.md
+++ b/src/commonmark/en/dhis2_android_implementation_guidelines_INDEX.md
@@ -1,0 +1,6 @@
+---
+title: 'DHIS 2 configuration guide for the Android capture app'
+---
+<!--DHIS2-SECTION-ID:index-->
+
+!SUBMODULE "dhis2-android-capture-app" "master" "docs/src/commonmark/en/dhis2_android_implementation_guideline_INDEX.md"


### PR DESCRIPTION
The Android Implementation guideline has been fully migrated from Google Docs to Markdown and is ready to be placed under the new docs portal.