### PR TITLE
docs: Add missing files for the 2.33 sysadmin guide

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,7 @@ generate "dhis2_scorecard_manual" "scorecard-app"
 echo "    - Implementer:" >> $myml
 generate "dhis2_implementation_guide" "implementer"
 generate "dhis2_android_capture_app" "android-app"
+generate "dhis2_android_MDM" "mdm"
 generate "user_stories_book" "user-stories"
 
 echo "    - Developer:" >> $myml

--- a/build_translations.sh
+++ b/build_translations.sh
@@ -54,6 +54,7 @@ if [ ${LOCALISE} -eq 1  ]; then
         echo "    - Implementer:" >> $myml
         translate "dhis2_implementation_guide" "implementer" "both" $lang $locale
         translate "dhis2_android_capture_app" "android-app" "both" $lang $locale
+		translate "dhis2_android_MDM" "mdm" "both" $lang $locale
         translate "user_stories_book" "user-stories" "both" $lang $locale
 
         echo "    - Developer:" >> $myml

--- a/src/commonmark/en/content/sysadmin/SMS-reporting.md
+++ b/src/commonmark/en/content/sysadmin/SMS-reporting.md
@@ -1,0 +1,85 @@
+# Using Gateways for SMS reporting 
+
+<!--DHIS2-SECTION-ID:sms_report_sending-->
+
+DHIS2 supports accepting data via [SMS](https://docs.dhis2.org/master/en/dhis2_user_manual_en/mobile.html), however, the SMS needs to be composed in a cryptic way to protect the information. The DHIS2 Android App acts as a transparent layer to send the information via SMS where the user does not have to worry about writing the SMS. To send SMSs with the Android App the SMS gateway need to be properly configured. This section explains the different options available and how to achieve that.
+
+## Sending SMS
+
+<!--DHIS2-SECTION-ID:sms_report_sening-->
+
+It is important to clarify firstly, that this section mainly concerns the set up of **receiving SMS** (from mobile devices to the DHIS2 server), which is necessary when considering using the App to send (sync) information recorded in the app to the DHIS2 server via SMS. In the App this can be set-up under the *Settings* > *SMS Settings*
+
+Sending SMS, i.e. from the DHIS2 server to mobile devices, is relatively simple to set up. If all that is required is the sending of notifications to users phones from DHIS2 when certain events occur (messaging, thresholds e.t.c.) only sending SMS is required.
+
+This can all be configured in the SMS Service Configuration page within the [Mobile Configuration section](https://docs.dhis2.org/master/en/user/html/mobile_sms_service.html).
+
+There is out of the box support for common providers such as *Bulk SMS* and *Clickatell*, and both providers support sending of SMS to numbers in most countries.
+
+Note also, it is possible to use a different SMS Gateway for sending and receiving SMS. So even if you set up a solution for receiving SMS below, it is still possible to use one of the aforementioned solutions above for sending SMS.
+
+## Using an Android device as SMS Gateway
+
+<!--DHIS2-SECTION-ID:sms_report_android_gateway-->
+
+The simplest solution by far is to use a dedicated Android device as your SMS Gateway. Any phone or tablet running Android OS (4.4, Kitkat or above) should be fine. It will require a constant internet connection, in order to forward messages to your DHIS2 server and it will also need a SIM card to receive the incoming SMS.
+
+You’ll need to download and install the DHIS2 Android SMS Gateway app on the mobile device. See a list of [releases](https://github.com/dhis2/dhis2-sms-android-gateway/releases) where you can download the latest APK file to install. There are instructions on the app page itself, but essentially you’ll just need to start the app and enter the details of your DHIS2 server (URL, username and password).
+
+Once this is set up and running, you then enter the phone number of this gateway device in the configuration page of any other mobile device using the DHIS2 Capture App. Then, when SMS are sent from these reporting devices, they will be received on the gateway device and automatically forwarded to the DHIS2 server where they will be processed.
+
+**Using this gateway device is perfect when testing the SMS functionality.** It would be fine when piloting projects that require SMS reporting. As long as the device is plugged into a power supply and has a constant internet connection it works well for small scale projects.
+
+However, when considering moving a project to production it would be necessary to investigate one of the more permanent and reliable solutions for gateways below.
+
+### Sending SMS using an Android Device Gateway
+
+This option is currently not supported nor documented.
+
+## Dedicated SMS Gateways
+
+<!--DHIS2-SECTION-ID:sms_report_dedicated_gateway-->
+
+This section discusses the use of more permanent and dedicated SMS gateways and the options available. Each of these options below will involve a provider (or yourself) having an SMPP connection to a phone carrier in country and using this connection to receive incoming SMS and forward them on to your DHIS2 server over the internet using HTTP.
+
+These solutions can either use a **long number** or **short code**. A long number is a standard mobile phone number of the type that most private people use, i.e. +61 400123123. A short code is simply a short number, such as 311. Short codes typically cost more to set up and maintain.
+
+### Ensuring incoming SMS to DHIS2 server are formatted correctly
+
+When sending incoming SMS to a DHIS2 server via the API you use the following URL: *https://<DHIS2_server_url>/api/sms/inbound*
+
+In DHIS2 version 2.34 and below, this endpoint requires the format of inbound SMS to be in a very specific format, i.e. the message itself must be a parameter called text, the phone number of the sender must be a parameter called originator.
+
+When using all of the below SMS gateway options, when you configure them to forward incoming SMS on to another web service, they will each have their own format, which will be different to the one expected by the DHIS2 API. For this reason then, it’s necessary to reformat them before sending them on to the DHIS2 server.
+
+One option is to run your own very simple web service, which simply receives the incoming SMS from the gateway provider, reformats it to the one required for DHIS2 and forwards it on to your DHIS2 API. Such a service would need to be written by a software developer.
+
+In DHIS2 version 2.35, it is planned to support these cases with a templating system for incoming SMS, so you can specify the format of the messages which will be sent from your provider. That way, you can configure the DHIS2 server to accept incoming SMS from any other SMS gateway provider and they can directly send incoming SMS to the DHIS2 API, without the need for such a formatting web service.
+
+### Using RapidPro
+
+[RapidPro](https://rapidpro.io/) is a service run by UNICEF in over 50 countries around the world. It is a collection of software which works with in-country phone carriers to enable organisations to design SMS solutions for their projects, such as SMS reporting or awareness campaigns.
+
+The RapidPro service will involve an SMPP connection to one or more phone carriers in-country, usually via a shortcode, potentially dedicated to Health work for NGOs. It’s then possible to add a webhook so that incoming SMS are forwarded to another web service, such as the formatting web service described above. If the shortcode is used for other purposes as well, it may be necessary to add the phone numbers of your reporting devices to a separate group, so that only the incoming SMS from those devices is forwarded to the webhook.
+
+RapidPro is currently set up and running in roughly half of the countries which are currently using or piloting DHIS2. Before considering one of the solutions below, which can be costly in terms of both finance and time, it is worth getting in contact with Unicef to see if RapidPro is available and if it can be used for health reporting in your country.
+
+### Using commercial SMS gateway providers
+
+Of the commercial SMS gateway providers mentioned in the Sending SMS section above, they will usually have capability to *send* SMS in most countries but can only support *receiving* SMS in a limited amount of countries. The majority of countries they support receiving SMS in are not those using DHIS2. Of the countries that are using DHIS2, most are already covered by having a RapidPro service running in-country.
+
+However, it is worth researching what commercial options are available for your country. In some countries there will be small national companies that provide SMS services, they’ll have existing SMPP connections with the phone providers you can use.
+
+### Using phone carriers directly
+
+If none of the above solutions are available it would be necessary to approach the phone carriers in your country directly. The first question to ask them would be whether they are aware of any companies which are operating SMPP connections with them which you may be able to approach.
+
+If not, as a final option, you would need to consider setting up and maintaining your own SMPP connection with the phone provider. However, not all phone providers might offer such a service.
+
+You would need to run your own server running software such as [Kannel](https://www.kannel.org/), which connects (usually via a VPN) to an SMPP service running in the phone providers network. With this in place, any incoming SMS for the configured long number or shortcode are sent from the phone carrier to your Kannel server and you can then forward on these messages as above.
+
+### Receiving concatenated or multipart SMS
+
+When syncing data via SMS with the DHIS2 Android App, it uses a compressed format to use as little space (characters of text) as possible. Despite this, it will quite often be the case that a message will extend over the 160 character limit of one standard SMS. On most modern mobile devices these messages will still be sent as one concatenated or multipart SMS, and received as one message. When sending between two mobile devices, when an Android device is used as the gateway, this should be handled without issue.
+
+When selecting an SMS gateway then, it is important to confirm that the phone carrier used supports concatenated SMS. Most of them will support this, but it is important to confirm as the SMS functionality will not work if SMS are split. This relies on something called a UDH (User Data Header). When discussing with providers then, ensure you ask if it is supported.

--- a/src/commonmark/en/content/sysadmin/audit.md
+++ b/src/commonmark/en/content/sysadmin/audit.md
@@ -1,0 +1,127 @@
+# Audit
+
+## Introduction
+
+DHIS2 supports a new audit service which is based on Apache ActiveMQ Artemis. Artemis is used as an asynchronous messaging system by DHIS2.
+
+After an entity is saved to database, an audit message will be sent to the Artemis message consumer service. The message will then be processed in a different thread.
+
+Audit logs can be retrieved from the DHIS2 database. Currently there is no UI or API endpoint available for retriving audit entries.
+
+
+## Single Audit table
+
+<!--DHIS2-SECTION-ID:audit_table-->
+
+All audit entries will be saved into one single table named `audit`
+
+| Column     | Type                        |                                                                                                                                                   |   |
+|------------|-----------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|---|
+| auditid    | integer                     |                                                                                                                                                   |   |
+| audittype  | text                        | READ, CREATE, UPDATE, DELETE, SEARCH                                                                                                                  |   |
+| auditscope | text                        | METADATA, AGGREGATE, TRACKER                                                                                                                        |   |
+| klass      | text                        | Audit Entity Java class name                                                                                                                      |   |
+| attributes | jsonb                       | Json string stores attributes of the audit entity, used for searching. Example: {"valueType":"TEXT", "categoryCombo":"SWQW313FQY", "domainType":"TRACKER"} |   |
+| data       | bytea                       | Compressed Json string of the Audit Entity. It is currently in byte array format and not human-readable, but a mechanism will be introduce in 2.34.1                                                                                                        |   |
+| createdat  | timestamp without time zone |                                                                                                                                                   |   |
+| createdby  | text                        |                                                                                                                                                   |   |
+| uid        | text                        |                                                                                                                                                   |   |
+| code       | text                        |                                                                                                                                                   |   |
+|            |                             |   
+
+
+
+The new Audit service makes use of two new concepts: Audit Scopes and Audit Type.
+
+## Audit Scope
+
+<!--DHIS2-SECTION-ID:audit_scope-->
+
+An Audit Scope is a logical area of the application which can be audited. Currently there are three Audit Scopes:
+
+```
+Tracker
+
+Metadata
+
+Aggregate
+```
+
+- For the Tracker Audit Scope, the audited objects are:
+Tracked Entity Instance, Tracked Entity Attribute Value, Enrollment, Event
+
+- For the Metadata Scope, all "metadata" objects are audited.
+
+- For the Aggregate Scope, the Aggregate Data Value objects are audited.
+
+
+## Audit Type
+
+<!--DHIS2-SECTION-ID:audit_type-->
+
+An Audit Type is an action that triggers an audit operation. Currently we support the following types:
+
+```
+READ
+
+CREATE
+
+UPDATE
+
+DELETE
+```
+
+As an example, when a new Tracked Entity Instance gets created, and if configured like so, the CREATE action is used to insert a new Audit entry in the audit db table.
+
+> **Caution**
+>
+> The READ Audit Type will generate a lot of data in database and may have an impact on the performance.
+
+## Setup
+
+<!--DHIS2-SECTION-ID:audit_configuration-->
+
+The audit system is automatically configured to audit for the following scopes and types:
+
+- CREATE, UPDATE, DELETE
+
+- METADATA, TRACKER, AGGREGATE
+
+**No action is required to activate the audit.**
+The audit can still be configured using the "audit matrix". The audit matrix is driven by 3 properties in dhis.conf:
+
+```
+audit.metadata
+
+audit.tracker
+
+audit.aggregate
+```
+
+Each property accepts a semicolon delimited list of valid Audit Types:
+
+```
+CREATE
+
+UPDATE
+
+DELETE
+
+READ
+```
+
+For instance, in order to only audit Tracker related object creation and deletion, the following property should be added to `dhis.conf`:
+
+```
+audit.tracker = CREATE;DELETE
+```
+
+In order to completely disable auditing, this is the configuration to use:
+```
+audit.metadata = DISABLED 
+
+audit.tracker = DISABLED 
+
+audit.aggregate = DISABLED
+```
+

--- a/src/commonmark/en/content/sysadmin/monitoring.md
+++ b/src/commonmark/en/content/sysadmin/monitoring.md
@@ -1,0 +1,411 @@
+# Monitoring
+
+## Introduction
+
+<!--DHIS2-SECTION-ID:monitoring-->
+
+DHIS2 can export [Prometheus](https://prometheus.io/) compatible metrics for monitoring DHIS2 nodes.
+
+This section describes the steps required to install Prometheus and [Grafana](https://grafana.com/) using a standard installation procedure (`apt-get`) and Docker and configure Grafana to show DHIS2 metrics.
+
+For a list of the metrics exposed by a DHIS2 instance, please refer to the monitoring guide on [GitHub](https://github.com/dhis2/wow-backend/blob/master/guides/monitoring.md).
+
+## Setup
+
+<!--DHIS2-SECTION-ID:monitoring_setup-->
+
+The next sections describe how to set up Prometheus and Grafana and how to set up Prometheus to pull data from one or more DHIS2 instances.
+
+### Installing Prometheus + Grafana on Ubuntu and Debian
+
+<!--DHIS2-SECTION-ID:prometheus-->
+
+- Download Prometheus from the official [download](https://prometheus.io/download/) page.
+
+- Make sure to filter for your operating system and your CPU architecture (Linux and amd64).
+
+- Make sure to select the latest stable version, and not the “rc” one, as it is not considered stable enough for now.
+
+- Download the archive, either by clicking on the link or using `wget`.
+
+```
+wget https://github.com/prometheus/prometheus/releases/download/v2.15.2/prometheus-2.15.2.linux-amd64.tar.gz
+```
+
+- Untar the zip 
+
+```
+tar xvzf prometheus-2.15.2.linux-amd64.tar.gz
+```
+
+The archive contains many important files, but here is the main ones you need to know.
+
+- `prometheus.yml`: the configuration file for Prometheus. This is the file that you are going to modify in order to tweak your Prometheus server, for example to change the scraping interval or to configure custom alerts;
+- `prometheus`: the binary for your Prometheus server. This is the command that you are going to execute to launch a Prometheus instance on your Linux box;
+- `promtool`: this is a command that you can run to verify your Prometheus configuration.
+
+### Configuring Prometheus as a service
+
+<!--DHIS2-SECTION-ID:prometheus_service-->
+
+- Create a `Prometheus` user with a `Prometheus` group.
+
+```
+useradd -rs /bin/false prometheus
+```
+
+- Move the Prometheus binaries to the local bin directory
+
+```
+cd prometheus-2.15.2.linux-amd64/ 
+cp prometheus promtool /usr/local/bin
+chown prometheus:prometheus /usr/local/bin/prometheus
+```
+
+- Create a folder in the `/etc` folder for Prometheus and move the console files, console libraries and the prometheus configuration file to this newly created folder.
+
+```
+mkdir /etc/prometheus
+cp -R consoles/ console_libraries/ prometheus.yml /etc/prometheus
+```
+
+Create a data folder at the root directory, with a prometheus folder inside.
+
+```
+mkdir -p data/prometheus
+chown -R prometheus:prometheus /data/prometheus /etc/prometheus/*
+```
+
+### Create a Prometheus service
+
+<!--DHIS2-SECTION-ID:prometheus_create_service-->
+
+To create a Prometheus _systemd_ service, head over to the `/lib/systemd/system` folder and create a new systemd file named `prometheus.service`.
+
+```
+cd /lib/systemd/system
+touch prometheus.service
+```
+
+- Edit the newly created file, and paste the following content inside:
+
+```properties
+[Unit]
+Description=Prometheus
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=prometheus
+Group=prometheus
+ExecStart=/usr/local/bin/prometheus \
+  --config.file=/etc/prometheus/prometheus.yml \
+  --storage.tsdb.path="/data/prometheus" \
+  --web.console.templates=/etc/prometheus/consoles \
+  --web.console.libraries=/etc/prometheus/console_libraries \
+  --web.listen-address=0.0.0.0:9090 \
+  --web.enable-admin-api
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- Save the file and enable the Prometheus service at startup
+
+```
+systemctl enable prometheus
+systemctl start prometheus
+```
+
+- Test that the service is running
+
+```
+systemctl status prometheus
+
+...
+Active: active (running)
+```
+
+- It should be now possible to access the Prometheus UI by accessing `http://localhost:9090`.
+
+
+### Set-up Nginx reverse proxy
+
+<!--DHIS2-SECTION-ID:prometheus_nginx-->
+
+Prometheus does not natively support authentication or TLS encryption. If Prometheus has to be exposed outside the boundaries of the local network, it is important to enable authentication and TLS encryption. The following steps show how to use Nginx as a reverse proxy.
+
+- Install Nginx, if not already installed
+
+```
+apt update
+apt-get install nginx
+```
+
+By default, Nginx will start listening for HTTP requests in the default `http` port, which is `80`.
+
+If there is already an Nginx instance running on the machine and you are unsure on which port it is listening on, run the following command:
+
+```
+> lsof | grep LISTEN | grep nginx
+
+nginx   15792   root   8u   IPv4   1140223421   0t0   TCP *:http (LISTEN)
+```
+
+The last column shows the port used by Nginx (`http` -> `80`).
+
+By default, Nginx configuration is located in `/etc/nginx/nginx.conf`
+
+Make sure that `nginx.conf` contains the `Virtual Host Config` section
+
+```
+##
+# Virtual Host Configs
+##
+
+include /etc/nginx/conf.d/*.conf;
+include /etc/nginx/sites-enabled/*;
+
+```
+
+- Create a new file in `/etc/nginx/conf.d` called `prometheus.conf`
+
+```
+touch /etc/nginx/conf.d/prometheus.conf
+```
+
+- Edit the newly created file, and paste the following content inside:
+
+```
+server {
+  listen 1234;
+
+  location / {
+    proxy_pass           http://localhost:9090/;
+  }
+}
+```
+
+- Restart Nginx  and browse to http://localhost:1234
+
+```
+systemctl restart nginx
+
+# in case of start-up errors
+journalctl -f -u nginx.service
+```
+
+- Configure Prometheus for reverse proxying, by editing `/lib/systemd/system/prometheus.service` and add the following argument to the list of arguments passed to the Prometheus executable.
+
+```
+--web.external-url=https://localhost:1234
+```
+
+- Restart the service
+
+```
+systemctl daemon-reload
+systemctl restart prometheus
+
+
+# in case of errors
+journalctl -f -u prometheus.service
+```
+
+### Enable reverse proxy authentication
+
+<!--DHIS2-SECTION-ID:prometheus_auth-->
+
+This section shows how to configure basic authentication via the reverse proxy. If you need a different authentication mechanism (SSO, etc.) please check the relevant documentation.
+
+- Make sure that `htpasswd` is installed on the system
+
+```
+apt-get install apache2-utils
+```
+
+- Create an authentication file
+
+```
+cd /etc/prometheus
+htpasswd -c .credentials admin 
+```
+
+Choose a strong password, and make sure that the pass file was correctly created.
+
+- Edit the previously created Nginx configuration file (`/etc/nginx/conf.d/prometheus.conf`), and add the authentication information.
+
+```
+server {
+  listen 1234;
+
+  location / {
+    auth_basic           "Prometheus";
+    auth_basic_user_file /etc/prometheus/.credentials;
+    proxy_pass           http://localhost:9090/;
+  }
+}
+```
+
+- Restart Nginx
+
+```
+systemctl restart nginx
+
+# in case of errors
+journalctl -f -u nginx.service
+```
+
+- `http://localhost:1234` should now prompt for username and password.
+
+### Installing Grafana on Ubuntu and Debian
+
+<!--DHIS2-SECTION-ID:grafana-->
+
+- Add a `gpg` key and install the OSS Grafana package from APT repo
+
+```sh
+apt-get install -y apt-transport-https
+
+wget -q -O - "https://packages.grafana.com/gpg.key" | sudo apt-key add -
+
+add-apt-repository "deb https://packages.grafana.com/oss/deb stable main"
+
+apt-get update
+
+apt-get install grafana
+```
+
+- If the system is using `systemd`, a new `grafana-service` is automatically created. Check the `systemd` file to gain some insight on the Grafana installation
+
+```
+cat /usr/lib/systemd/system/grafana-server.service
+```
+
+This file is quite important because it offers information about the newly installed Grafana instance.
+
+The file shows:
+
+The **Grafana server binary** is located at `/usr/sbin/grafana-server`.
+The file that defines all the **environment variables** is located at `/etc/default/grafana-server`
+The **configuration file** is given via the `CONF_FILE` environment variable.
+The **PID of the file** is also determined by the `PID_FILE_DIR` environment variable.
+**Logging**, **data**, **plugins** and **provisioning** paths are given by environment variables.
+
+- Start the server
+
+```
+systemctl start grafana-server
+```
+
+- Access Grafana web console: http://localhost:3000
+
+The default login for Grafana is `admin` and the default password is also `admin`.
+You will be prompted to change the password on first access.
+
+- Configure Prometheus as a Grafana datasource
+
+Access to the datasources panel by clicking on `Configuration` > `Data sources` via the left menu.
+
+Click on `Add a datasource`
+
+Select a Prometheus data source on the next window.
+
+Configure the datasource according to the Prometheus setup (use authentication, TSL, etc.)
+
+### Installing Prometheus + Grafana using Docker
+
+<!--DHIS2-SECTION-ID:prometheus_grafana_docker-->
+
+This section describes how to start-up a Prometheus stack containing Prometheus and Grafana.
+
+The configuration is based on this project: https://github.com/vegasbrianc/prometheus
+
+- Clone this Github project: https://github.com/vegasbrianc/prometheus
+
+- Start the Prometheus stack using:
+
+```
+docker stack deploy -c docker-stack.yml prom
+```
+
+The above command, may result in the following error:
+
+*This node is not a swarm manager. Use "docker swarm init" or "docker swarm join" to connect this node to swarm and try again*
+
+If that happens, you need to start Swarm. You can use the following command line:
+
+```
+docker swarm init --advertise-addr <YOUR_IP>
+```
+
+Once this command runs successfully, you should be able to run the previous command without problems.
+
+The stack contains also a Node exporter for Docker monitoring. If you are not interested in Docker monitoring, you can comment out the relevant sections in the `docker-stack.yml` file:
+
+- `node-exporter`
+- `cadvisor`
+
+- To stop the Prometheus stack:
+
+```
+docker stack rm prom
+```
+
+The Prometheus configuration (`prometheus.yml`) file is located in the `prometheus` folder.
+
+- Access Grafana web console at: http://localhost:3000 with username: `admin` and password: `foobar`
+
+### Configure Prometheus to pull metrics from one or more DHIS2 instances
+
+<!--DHIS2-SECTION-ID:prometheus_dhis2-->
+
+Prior to using Prometheus, it needs basic configuring. Thus, we need to create a configuration file named `prometheus.yml`
+
+> **Note**
+>
+> The configuration file of Prometheus is written in YAML which strictly forbids to use tabs. If your file is incorrectly formatted, Prometheus will not start. Be careful when you edit it.
+
+Prometheus’ configuration file is divided into three parts: `global`, `rule_files`, and `scrape_configs`.
+
+In the global part we can find the general configuration of Prometheus: `scrape_interval` defines how often Prometheus scrapes targets, `evaluation_interval` controls how often the software will evaluate rules. Rules are used to create new time series and for the generation of alerts.
+
+The `rule_files` block contains information of the location of any rules we want the Prometheus server to load.
+
+The last block of the configuration file is named `scape_configs` and contains the information which resources Prometheus monitors.
+
+A simple DHIS2 Prometheus monitoring file looks like this example:
+
+```yaml
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s 
+
+scrape_configs:
+  - job_name: 'dhis2'
+    metrics_path: '/dhis/api/metrics'
+    basic_auth:
+      username: admin
+      password: district
+    static_configs:
+      - targets: ['localhost:80']
+```
+
+The global `scrape_interval` is set to 15 seconds which is enough for most use cases.
+
+In the `scrape_configs` part we have defined the DHIS2 exporter.
+The `basic_auth` blocks contains the credentials required to access the `metrics` API: consider creating an ad-hoc user only for accessing the `metrics` endpoint.
+
+Prometheus may or may not run on the same server as DHIS2: in the above configuration, it is assumed that Prometheus monitors only one DHIS2 instance, running on the same server as Prometheus, so we use `localhost`.
+
+### Configure the DHIS2 exporter
+
+<!--DHIS2-SECTION-ID:dhis2_metrics_conf-->
+
+The monitoring subsystem is disabled by default in DHIS2.
+
+Each metrics cluster has to be explicitly enabled in order for the metrics to be exported. To configure DHIS2 to export one or more metrics, check this [document](https://github.com/dhis2/wow-backend/blob/master/guides/monitoring.md#dhis2-monitoring-configuration).
+

--- a/src/commonmark/en/dhis2_android_MDM_INDEX.md
+++ b/src/commonmark/en/dhis2_android_MDM_INDEX.md
@@ -1,0 +1,1 @@
+!SUBMODULE "dhis2-android-capture-app" "master" "docs/src/commonmark/en/dhis2_android_MDM_INDEX.md"

--- a/src/commonmark/en/dhis2_system_administration_guide_INDEX.md
+++ b/src/commonmark/en/dhis2_system_administration_guide_INDEX.md
@@ -5,6 +5,4 @@ title: 'DHIS 2 System Administration guide'
 
 !INCLUDE "content/common/about-this-guide.md"
 !INCLUDE "content/sysadmin/installation.md"
-!INCLUDE "content/sysadmin/monitoring.md"
-!INCLUDE "content/sysadmin/audit.md"
 !INCLUDE "content/sysadmin/SMS-reporting.md"

--- a/src/commonmark/en/dhis2_system_administration_guide_INDEX.md
+++ b/src/commonmark/en/dhis2_system_administration_guide_INDEX.md
@@ -5,3 +5,6 @@ title: 'DHIS 2 System Administration guide'
 
 !INCLUDE "content/common/about-this-guide.md"
 !INCLUDE "content/sysadmin/installation.md"
+!INCLUDE "content/sysadmin/monitoring.md"
+!INCLUDE "content/sysadmin/audit.md"
+!INCLUDE "content/sysadmin/SMS-reporting.md"


### PR DESCRIPTION
The guide was missing some files.
Also added the SMS reporting one (related to Android App and the gateways that is already present in master and 2.34 -PR-)