### PR TITLE
fix: complete dhis.conf part on how to disable auditing

### DIFF
--- a/src/commonmark/en/content/sysadmin/audit.md
+++ b/src/commonmark/en/content/sysadmin/audit.md
@@ -116,10 +116,10 @@ audit.tracker = CREATE;DELETE
 
 In order to completely disable auditing, this is the configuration to use:
 ```
-audit.metadata = 
+audit.metadata = DISABLED
 
-audit.tracker = 
+audit.tracker = DISABLED
 
-audit.aggregate =
+audit.aggregate = DISABLED
 ```
 


### PR DESCRIPTION
It seemed incomplete so it is copied from 2.35 docs https://docs.dhis2.org/2.35/en/dhis2_system_administration_guide/audit.html