### PR TITLE
Tomcat restart after new CA scheduler job

### DIFF
--- a/src/commonmark/en/content/user/scheduling.md
+++ b/src/commonmark/en/content/user/scheduling.md
@@ -137,7 +137,9 @@ The analytics table job will by default populate data for all years and data ele
 - **Last years:** The number of last years to populate analytics tables for. As an example, if you specify 2 years, the process will update the two last years worth of data, but not update older data. This parameter is useful to reduce the time the process takes to complete, and is appropriate if older data has not changed, and when updating the latest data is desired.
 - **Skip resource tables:** Skip resource tables during the analytics table update process. This reduces the time the process takes to complete, but leads to changes in metadata not being reflected in the analytics data.
 
-After addition of new continuous analytics table jobs it can be necessary to restart Tomcat to initialize the scheduler job correctly.
+> **Important**
+>
+> After addition of new continuous analytics table jobs it can be necessary to restart Tomcat to initialize the scheduler job correctly.
 
 ### Data synchronization
 

--- a/src/commonmark/en/content/user/scheduling.md
+++ b/src/commonmark/en/content/user/scheduling.md
@@ -137,6 +137,8 @@ The analytics table job will by default populate data for all years and data ele
 - **Last years:** The number of last years to populate analytics tables for. As an example, if you specify 2 years, the process will update the two last years worth of data, but not update older data. This parameter is useful to reduce the time the process takes to complete, and is appropriate if older data has not changed, and when updating the latest data is desired.
 - **Skip resource tables:** Skip resource tables during the analytics table update process. This reduces the time the process takes to complete, but leads to changes in metadata not being reflected in the analytics data.
 
+After addition of new continuous analytics table jobs it can be necessary to restart Tomcat to initialize the scheduler job correctly.
+
 ### Data synchronization
 
 <!--DHIS2-SECTION-ID:scheduling_data_sync-->


### PR DESCRIPTION
A NullPointerException without any stacktrace was thrown every time the job started, when _not_ doing a Tomcat restart. This can also be verified on play.dhis2.org/2.34.2 (but not by me as I cannot restart tomcat).

If agreed, what would be the recommended way to add the change to other branches (master, 2.35)?