### PR TITLE
docs: dataIntegrity API requests for triggering and polling result

### DIFF
--- a/src/commonmark/en/content/developer/web-api/data-validation.md
+++ b/src/commonmark/en/content/developer/web-api/data-validation.md
@@ -605,12 +605,11 @@ the analysis performed are described in the user manual.
 The operation of measuring data integrity is a fairly resource (and
 time) demanding task. It is therefore run as an asynchronous process and
 only when explicitly requested. Starting the task is done by forming an
-empty POST request to the *dataIntegrity* endpoint like so (demonstrated
-in curl syntax):
+empty POST request to the *dataIntegrity* endpoint:
 
-```bash
-GET /api/33/dataIntegrity
-```
+
+    GET https://play.dhis2.org/demo/api/dataIntegrity
+
 
 If successful the request will return HTTP 202 immediately. The location
 header of the response points to the resource used to check the status
@@ -627,9 +626,9 @@ can hence be used to wait for the task to finish.
 Once data integrity is finished running the result can be fetched from
 the `system/taskSummaries` resource like so:
 
-```bash
-GET /api/33/system/taskSummaries/DATAINTEGRITY
-```
+
+    GET /api/system/taskSummaries/DATA_INTEGRITY
+
 
 The returned object contains a summary for each point of analysis,
 listing the names of the relevant integrity violations. As stated in the

--- a/src/commonmark/en/content/developer/web-api/data-validation.md
+++ b/src/commonmark/en/content/developer/web-api/data-validation.md
@@ -607,7 +607,7 @@ time) demanding task. It is therefore run as an asynchronous process and
 only when explicitly requested. Starting the task is done by forming an
 empty POST request to the *dataIntegrity* endpoint:
 
-    GET https://play.dhis2.org/demo/api/dataIntegrity
+    POST /api/dataIntegrity
 
 If successful the request will return HTTP 202 immediately. The location
 header of the response points to the resource used to check the status

--- a/src/commonmark/en/content/developer/web-api/data-validation.md
+++ b/src/commonmark/en/content/developer/web-api/data-validation.md
@@ -607,9 +607,7 @@ time) demanding task. It is therefore run as an asynchronous process and
 only when explicitly requested. Starting the task is done by forming an
 empty POST request to the *dataIntegrity* endpoint:
 
-
     GET https://play.dhis2.org/demo/api/dataIntegrity
-
 
 If successful the request will return HTTP 202 immediately. The location
 header of the response points to the resource used to check the status
@@ -626,9 +624,7 @@ can hence be used to wait for the task to finish.
 Once data integrity is finished running the result can be fetched from
 the `system/taskSummaries` resource like so:
 
-
     GET /api/system/taskSummaries/DATA_INTEGRITY
-
 
 The returned object contains a summary for each point of analysis,
 listing the names of the relevant integrity violations. As stated in the


### PR DESCRIPTION
This PR fixes the API requests to conform to the format of other endpoints to be client-agnostic (no curl) and fixes a bug in how to poll the response after successful triggering.


### Testing

**Triggering**

Request:

```
curl -X POST 'https://play.dhis2.org/2.35.1/api/dataIntegrity' -u admin:district
```

Response:
```
{“httpStatus”:“OK”,“httpStatusCode”:200,“status”:“OK”,“message”:“Initiated runAsyncDataIntegrity”,“response”:{“name”:“runAsyncDataIntegrity”,“id”:“A6KxmXHKpuc”,“created”:“2021-01-27T13:16:16.620”,“jobType”:“DATA_INTEGRITY”,“jobStatus”:“SCHEDULED”,“relativeNotifierEndpoint”:“/api/system/tasks/DATA_INTEGRITY/A6KxmXHKpuc”}}
```

**Polling**

Request doesn't work (as documented before the PR):
```
curl 'https://play.dhis2.org/2.35.1/api/system/taskSummaries/DATAINTEGRITY' -u admin:district
{“httpStatus”:“Internal Server Error”,“httpStatusCode”:500,“status”:“ERROR”,“message”:“No enum constant org.hisp.dhis.scheduling.JobType.DATAINTEGRITY”}
```

Suggested fix for the request:

```
curl 'https://play.dhis2.org/2.35.1/api/system/taskSummaries/DATA_INTEGRITY' -u admin:district
```

Response:

```
{"dataElementsWithoutDataSet":["All sterilisation equipment is validated / licensed","Cabin fever","Deaths due to tuberculosis among HIV-negative people (per 100 000 population)", ....
```