### PR TITLE
docs: Hide dashboard widget app name DHIS2-9604

### DIFF
--- a/src/commonmark/en/content/developer/apps.md
+++ b/src/commonmark/en/content/developer/apps.md
@@ -98,6 +98,18 @@ Among the properties are:
         }
      }
 
+  - A *settings* property is optional, and can be used on a dashboard
+    widget app to suppress showing the widget title when the widget is
+    displayed on a dashboard:
+
+<!-- end list -->
+
+    "settings": {
+        "dashboardWidget": {
+            "hideTitle": true
+        }
+    }
+
 The namespace property can be added if your app is utilizing the
 dataStore or userDataStore api. When adding the namespace property, only
 users with access to your app are allowed to make changes to the


### PR DESCRIPTION
This documents the backend change described in [DHIS2-9604](https://jira.dhis2.org/browse/DHIS2-9604). A setting in manifest.webapp can be used to suppress a dashboard widget app title from being displayed when the dashboard displays the widget.