### PR TITLE
docs: Gather stats in dashboard views DHIS2-9554

### DIFF
--- a/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
+++ b/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
@@ -634,6 +634,11 @@ The available system settings are listed below.
 <td></td>
 <td>No</td>
 </tr>
+<tr class="even">
+<td>keyGatherAnalyticalObjectStatisticsInDashboardViews</td>
+<td>Whether to gather analytical object statistics on objects viewed within a dashboard</td>
+<td>No</td>
+</tr>
 </tbody>
 </table>
 

--- a/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
+++ b/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
@@ -636,7 +636,7 @@ The available system settings are listed below.
 </tr>
 <tr class="even">
 <td>keyGatherAnalyticalObjectStatisticsInDashboardViews</td>
-<td>Whether to gather analytical object statistics on objects viewed within a dashboard</td>
+<td>Whether to gather analytical statistics on objects when they are viewed within a dashboard</td>
 <td>No</td>
 </tr>
 </tbody>

--- a/src/commonmark/en/content/user/system-settings.md
+++ b/src/commonmark/en/content/user/system-settings.md
@@ -92,6 +92,12 @@
 <td><strong>Acceptance required before approval</strong></td>
 <td>When this setting is selected, acceptance of data will be required first before submission to the next approval level is possible.</td>
 </tr>
+<tr class="even">
+<td><strong>Gather analytical object statistics in dashboard views</strong></td>
+<td>Gather usage analytics data when an analytical object (e.g. map, chart, etc.)
+is viewed within a dashboard. Without this setting, analytics data is gathered only
+when the object is viewed individually outside of the dashboard.</td>
+</tr>
 </tbody>
 </table>
 

--- a/src/commonmark/en/content/user/system-settings.md
+++ b/src/commonmark/en/content/user/system-settings.md
@@ -94,9 +94,9 @@
 </tr>
 <tr class="even">
 <td><strong>Gather analytical object statistics in dashboard views</strong></td>
-<td>Gather usage analytics data when an analytical object (e.g. map, chart, etc.)
-is viewed within a dashboard. Without this setting, analytics data is gathered only
-when the object is viewed individually outside of the dashboard.</td>
+<td>Gather usage analytics data when analytical objects (e.g., maps, charts, etc.)
+are viewed within a dashboard. Without this setting, analytics data on the objects 
+is gathered only when the objects are viewed outside of a dashboard.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
See [DHIS2-9554](https://jira.dhis2.org/browse/DHIS2-9554). Documents the new general system setting _Gather analytical object statistics in dashboard views_ in the User Guide and the Developer Guide.