### PR TITLE
docs: Passive dashboard views setting DHIS2-10447

### DIFF
--- a/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
+++ b/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
@@ -641,7 +641,7 @@ The available system settings are listed below.
 </tr>
 <tr class="odd">
 <td>keyCountPassiveDashboardViewsInUsageAnalytics</td>
-<td>Whether usage analytics counts passive dashboard views (such as when the user first logs in)</td>
+<td>(Reserved for future use)</td>
 <td>No</td>
 </tr>
 </tbody>

--- a/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
+++ b/src/commonmark/en/content/developer/web-api/settings-and-configuration.md
@@ -639,6 +639,11 @@ The available system settings are listed below.
 <td>Whether to gather analytical statistics on objects when they are viewed within a dashboard</td>
 <td>No</td>
 </tr>
+<tr class="odd">
+<td>keyCountPassiveDashboardViewsInUsageAnalytics</td>
+<td>Whether usage analytics counts passive dashboard views (such as when the user first logs in)</td>
+<td>No</td>
+</tr>
 </tbody>
 </table>
 

--- a/src/commonmark/en/content/user/system-settings.md
+++ b/src/commonmark/en/content/user/system-settings.md
@@ -100,7 +100,7 @@ is gathered only when the objects are viewed outside of a dashboard.</td>
 </tr>
 <tr class="odd">
 <td><strong>Include passive dashboard views in usage analytics statistics</strong></td>
-<td>When this setting is selected, a passive dashboard view (such as happens when the user first logs in) will be counted as a view of that dashboard.</td>
+<td>(Reserved for future use)</td>
 </tr>
 </tbody>
 </table>

--- a/src/commonmark/en/content/user/system-settings.md
+++ b/src/commonmark/en/content/user/system-settings.md
@@ -98,6 +98,10 @@
 are viewed within a dashboard. Without this setting, analytics data on the objects 
 is gathered only when the objects are viewed outside of a dashboard.</td>
 </tr>
+<tr class="odd">
+<td><strong>Include passive dashboard views in usage analytics statistics</strong></td>
+<td>When this setting is selected, a passive dashboard view (such as happens when the user first logs in) will be counted as a view of that dashboard.</td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
See [DHIS2-10447](https://jira.dhis2.org/browse/DHIS2-10447). Adds a system setting that, when set, causes usage analytics to count passive dashboard views (such as when the user first logs in).