### PR TITLE
docs: Add dashboard 'restrictFilters' DHIS2-10307

### DIFF
--- a/src/commonmark/en/content/developer/web-api/visualizations.md
+++ b/src/commonmark/en/content/developer/web-api/visualizations.md
@@ -47,6 +47,7 @@ brevity).
   "name": "Mother and Child Health",
   "href": "https://play.dhis2.org/demo/api/dashboards/vQFhmLJU5sK",
   "publicAccess": "--------",
+  "restrictFilters": false,
   "externalAccess": false,
   "itemCount": 17,
   "displayName": "Mother and Child Health",


### PR DESCRIPTION
See [DHIS2-10307](https://jira.dhis2.org/browse/DHIS2-10307). The Developer Guide shows a sample request to return a dashboard object by issuing a GET request to:

`/api/dashboards/vQFhmLJU5sK.json`

This doc PR updates what is returned from this sample request. The Developer Guide did not go into detail about every property that is associated with a dashboard, how to change it, etc., so I did not add this detail for this field either.