### PR TITLE
docs: Add 'dataValues/file' DHIS2-7757

### DIFF
--- a/src/commonmark/en/content/developer/web-api/data.md
+++ b/src/commonmark/en/content/developer/web-api/data.md
@@ -981,7 +981,13 @@ data values will behave just like other data values which store text
 content, but should be handled differently in order to produce
 meaningful input and output.
 
-The process of storing one of these data values roughly goes like this:
+There are two methods of storing FileResource data values.
+
+**The Easy Way:** Upload the file to the `/api/dataValues/file` endpoint as
+described in the file resource section.
+
+**The Hard Way:** If you are working with a version of DHIS2 before 2.36,
+then the process is:
 
 1.  Upload the file to the `/api/fileResources` endpoint as described
     in the file resource section.

--- a/src/commonmark/en/content/developer/web-api/data.md
+++ b/src/commonmark/en/content/developer/web-api/data.md
@@ -986,8 +986,8 @@ There are two methods of storing FileResource data values.
 **The Easy Way:** Upload the file to the `/api/dataValues/file` endpoint as
 described in the file resource section.  This works on versions 2.36 and later.
 
-**The Hard Way:** If you are working with a version of DHIS2 before 2.36,
-then the process is:
+**The Hard Way:** If you are writing code that needs to be compatible
+with versions of DHIS2 before 2.36, then the process is:
 
 1.  Upload the file to the `/api/fileResources` endpoint as described
     in the file resource section.

--- a/src/commonmark/en/content/developer/web-api/data.md
+++ b/src/commonmark/en/content/developer/web-api/data.md
@@ -984,7 +984,7 @@ meaningful input and output.
 There are two methods of storing FileResource data values.
 
 **The Easy Way:** Upload the file to the `/api/dataValues/file` endpoint as
-described in the file resource section.
+described in the file resource section.  This works on versions 2.36 and later.
 
 **The Hard Way:** If you are working with a version of DHIS2 before 2.36,
 then the process is:

--- a/src/commonmark/en/content/developer/web-api/metadata.md
+++ b/src/commonmark/en/content/developer/web-api/metadata.md
@@ -3947,16 +3947,29 @@ The contents of file resources are not directly accessible but are
 referenced from other objects (such as data values) to store binary
 content of virtually unlimited size.
 
-Creation of the file resource itself is done through the `/api/fileResources` endpoint as a multipart upload POST-request:
+Creation of the file resource itself is done through either `/api/fileResources`
+or `/api/dataValues/file` as a multipart upload POST-request:
 
 ```bash
 curl "https://server/api/fileResources" -X POST
-  -F "file=@/Path/to/file;filename=name-of-file.png"
+  -F "file=@/path/to/file/name-of-file.png"
 ```
 
-The only form parameter required is the *file* which is the file to
-upload. The filename and content-type should also be included in the
-request but will be replaced with defaults when not supplied.
+or
+
+```bash
+curl "https://server/api/dataValues/file?de=xPTAT98T2Jd
+  &pe=201301&ou=DiszpKrYNg8&co=Prlt0C1RF0s" -X POST
+  -F "file=@/path/to/file/name-of-file.png"
+```
+
+For the `api/fileResources` endpoint, the only form parameter required is
+*file*, which is the file to upload. For the `api/dataValues/file`
+endpoint, the parameters required are the same as for a post to
+`api/dataValues`, with the addition of *file*.
+
+The filename and content-type should also be included in the request but 
+will be replaced with defaults when not supplied.
 
 On successfully creating a file resource the returned data will contain
 a `response` field which in turn contains the `fileResource` like this:

--- a/src/commonmark/en/content/developer/web-api/metadata.md
+++ b/src/commonmark/en/content/developer/web-api/metadata.md
@@ -3947,7 +3947,7 @@ The contents of file resources are not directly accessible but are
 referenced from other objects (such as data values) to store binary
 content of virtually unlimited size.
 
-To create a file resource without creating a corresponding data value,
+To create a file resource that does not require a corresponding data value,
 POST to the endpoint `/api/fileResources` with a multipart upload:
 
 ```bash
@@ -3956,7 +3956,7 @@ curl "https://server/api/fileResources" -X POST
 ```
 
 To create both a file resource and a data value that references the file,
-POST to the `/api/dataValues/file` endpoint:
+POST to the `/api/dataValues/file` endpoint in DHIS 2.36 or later:
 
 ```bash
 curl "https://server/api/dataValues/file?de=xPTAT98T2Jd

--- a/src/commonmark/en/content/developer/web-api/metadata.md
+++ b/src/commonmark/en/content/developer/web-api/metadata.md
@@ -3947,15 +3947,16 @@ The contents of file resources are not directly accessible but are
 referenced from other objects (such as data values) to store binary
 content of virtually unlimited size.
 
-Creation of the file resource itself is done through either `/api/fileResources`
-or `/api/dataValues/file` as a multipart upload POST-request:
+To create a file resource without creating a corresponding data value,
+POST to the endpoint `/api/fileResources` with a multipart upload:
 
 ```bash
 curl "https://server/api/fileResources" -X POST
   -F "file=@/path/to/file/name-of-file.png"
 ```
 
-or
+To create both a file resource and a data value that references the file,
+POST to the `/api/dataValues/file` endpoint:
 
 ```bash
 curl "https://server/api/dataValues/file?de=xPTAT98T2Jd


### PR DESCRIPTION
Adds information about using the new dataValues/file endpoint, which provides a smoother experience than the old api/fileResources endpoint for some use cases.