### PR TITLE
docs: Document validation functions DHIS2-7581

### DIFF
--- a/src/commonmark/en/content/user/configure-metadata.md
+++ b/src/commonmark/en/content/user/configure-metadata.md
@@ -3300,6 +3300,69 @@ message summaries. This is useful, for example, if you want to send
 individual messages for high-priority disease outbreaks, and summaries
 for low-priority routine data validation errors.
 
+#### About validation rule functions
+
+You can use the following functions in a validation rule left side
+or right side:
+
+<table>
+<caption>Validation Rule functions</caption>
+<colgroup>
+<col style="width: 33%" />
+<col style="width: 33%" />
+<col style="width: 33%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th><p>Validation Rule Function</p></th>
+<th><p>Arguments</p></th>
+<th><p>Description</p></th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><p>if</p></td>
+<td><p>(boolean-expr, true-expr, false-expr)</p></td>
+<td><p>Evaluates the boolean expression and if true returns the true expression value, if false returns the false expression value. The arguments must follow the rules for any indicator expression.</p></td>
+</tr>
+<tr class="even">
+<td><p>isNull</p></td>
+<td><p>(element)</p></td>
+<td><p>Returns true if the element value is missing (null), otherwise false.</p></td>
+</tr>
+<tr class="odd">
+<td><p>isNotNull</p></td>
+<td><p>(element)</p></td>
+<td><p>Returns true if the element value is not missing (not null), otherwise false.</p></td>
+</tr>
+<tr class="even">
+<td><p>firstNonNull</p></td>
+<td><p>(element [, element ...])</p></td>
+<td><p>Returns the value of the first element that is not missing (not null). Can be provided any number of arguments. Any argument may also be a numeric or string literal, which will be returned if all the previous objects have missing values.</p></td>
+</tr>
+<tr class="odd">
+<td><p>greatest</p></td>
+<td><p>(expression [, expression ...])</p></td>
+<td><p>Returns the greatest (highest) value of the expressions given. Can be provided any number of arguments.</p></td>
+</tr>
+<tr class="even">
+<td><p>least</p></td>
+<td><p>(expression [, expression ...])</p></td>
+<td><p>Returns the least (lowest) value of the expressions given. Can be provided any number of arguments.</p></td>
+</tr>
+<tr class="odd">
+<td><p>log</p></td>
+<td><p>(expression [, base ])</p></td>
+<td><p>Returns the natural logarithm (base e) of the numeric expression. If an integer is given as a second argument, returns the logarithm using that base.</p></td>
+</tr>
+<tr class="even">
+<td><p>log10</p></td>
+<td><p>(expression)</p></td>
+<td><p>Returns the common logarithm (base 10) of the numeric expression.</p></td>
+</tr>
+</tbody>
+</table>
+
 ### Create or edit a validation rule
 
 <!--DHIS2-SECTION-ID:create_validation_rule-->


### PR DESCRIPTION
In the comments for [DHIS2-7581 Add Indicator functions to the UI](https://jira.dhis2.org/browse/DHIS2-7581), I mentioned that the User Guide is up to date on which functions can be used in Indicators, Predictors, Program indicators, and Validation rules. However it seems that we had never made a table of functions that can be used with validation rules.

This PR adds that table.

Mostly the functions are the same between Indicators, Predictors, and Validation rules, but they also have some differences. (Program indicators have many more functions, the d2: functions.) At some point we could consider a common table of expression functions to reduce the redundancy in the documentation, but an argument could also be made for keeping the current structure of multiple tables--this may be more easily accessible to the reader.