### PR TITLE
fix: Aligned document with AbstractProvider_java

### DIFF
--- a/sysadmin/installation.md
+++ b/sysadmin/installation.md
@@ -721,7 +721,7 @@ oidc.provider.google.client_id = my_client_id
 oidc.provider.google.client_secret = my_client_secret
 
 # DHIS 2 instance URL, do not end with a slash, e.g.: https://dhis2.org/demo
-oidc.provider.google.redirect_baseurl = (protocol)://(host)/(optional app context)
+oidc.provider.google.redirect_url = (protocol)://(host)/(optional app context)
 
 # Optional, defaults to 'email'
 oidc.provider.google.mapping_claim = email
@@ -765,7 +765,7 @@ oidc.provider.azure.0.client_id = my_azure_ad_client_id
 oidc.provider.azure.0.client_secret = my_azure_ad_client_secret
 
 # DHIS 2 instance URL, do not end with a slash, e.g.: https://dhis2.org/demo
-oidc.provider.azure.0.redirect_baseurl = (protocol)://(host)/(optional app context)
+oidc.provider.azure.0.redirect_url = (protocol)://(host)/(optional app context)
 
 # Optional, defaults to 'email'
 oidc.provider.azure.0.mapping_claim = email
@@ -871,7 +871,7 @@ oidc.provider.google.client_id = my_client_id
 oidc.provider.google.client_secret = my_client_secret
 
 # DHIS 2 instance URL, do not end with a slash, e.g.: https://dhis2.org/demo
-oidc.provider.google.redirect_baseurl = (protocol)://(host)/(optional app context)
+oidc.provider.google.redirect_url = (protocol)://(host)/(optional app context)
 
 # Optional, defaults to 'email'
 oidc.provider.google.mapping_claim = email


### PR DESCRIPTION
We (WHO) are trying to deploy SSO everywhere using our IDP, AzureAD.

Yesterday I was working with some colleagues in Cairo to configure on of their DHIS2 apps with SSO, and we ran into an issue in which DHIS seemed to ignore our redirect_baseurl configuration. So I grabbed a copy of the source, and found this:

The property name is constructed here, in org.hisp.dhis.security.oidc.provider.AzureProfider.java:
```
builder.redirectUri( StringUtils.firstNonBlank(
            properties.getProperty( propertyPrefix + REDIRECT_URL ),
            DEFAULT_REDIRECT_TEMPLATE_URL ) );
```

And REDIRECT_URL, is inherited from AbstractProvider.java here:

```
    public static final String REDIRECT_URL = "redirect_url";
```

So the correct property name is redirect_url not redirect_baseurl.
