### PR TITLE
docs: removed obsolete note, update doc for "paging" parameter remova…

### DIFF
--- a/developer/web-api/new-tracker.md
+++ b/developer/web-api/new-tracker.md
@@ -1125,11 +1125,6 @@ Tracker export endpoints deal with the following Tracker objects:
 > 
 > These endpoints adopt the new naming convention documented in **[Changes in the API](#Changes-in-the-API)** 
 
-> **_NOTE 3:_**
-> 
-> The following functionalities are still missing but available in older endpoints:
-> - field filtering
-
 ### Common request parameters
 
 The following endpoint supports standard parameters for pagination.
@@ -1146,8 +1141,7 @@ The following endpoint supports standard parameters for pagination.
 |`page`|`Integer`| Any positive integer |Page number to return. Defaults to 1 if missing|
 |`pageSize`|`Integer`| Any positive integer |Page size. Defaults to 50. |
 |`totalPages`|`Boolean`| `true`&#124;`false` |Indicates whether to return the total number of pages in the response |
-|`skipPaging`|`Boolean`| `true`&#124;`false` |Indicates whether paging should be ignored and all rows should be returned|
-|`paging`|`Boolean`| `true`&#124;`false`  | Indicates whether paging is enabled| 
+|`skipPaging`|`Boolean`| `true`&#124;`false` |Indicates whether paging should be ignored and all rows should be returned. Defaults to `false`, meaning that by default all requests are paginated, unless `skipPaging=true`|
 |`order`|`String`|comma-delimited list of `OrderCriteria` in the form of `propName:sortDirection`.<br><br> Example: `createdAt:desc`<br><br>**Note:** `propName` is case sensitive, `sortDirection` is case insensitive|Sort the response based on given `OrderCriteria`|
 
 > **_NOTE_**


### PR DESCRIPTION
Ordering was already documented.
This PR removes an obsolete NOTE which was hanging there for no reason.
It also describe the new default for pagination and removal of "paging" flag in the request
