### PR TITLE
docs: adds paragraph on restricted namespaces [DHIS2-9091]

### DIFF
--- a/src/developer/web-api/data-store.md
+++ b/src/developer/web-api/data-store.md
@@ -13,6 +13,11 @@ is not reserved, no specific access is required to use it.
 
     /api/33/dataStore
 
+Note that there are reserved namespaces used by the system that require 
+special authority to be able to read or write entries. 
+For example the namespace for the android settings app `ANDROID_SETTINGS_APP`
+will require `F_METADATA_MANAGE` authority.
+
 ### Data store structure { #webapi_data_store_structure } 
 
 Data store entries consist of a namespace, key and value. The


### PR DESCRIPTION
Since the existence of the `ANDROID_SETTINGS_APP` is disclosed to any user in our API, like here https://debug.dhis2.org/dev/api/dataStore/ I think it cannot hurt to mention what authority is needed to gain access to the name-space.