### PR TITLE
Update installation.md

### DIFF
--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -341,7 +341,7 @@ connection.password = xxxx
 # server.https = on
 
 # Server base URL
-# server.base.url = https://server.com/
+# server.base.url = https://server.com
 ```
 
 It is strongly recommended to enable the `server.https` setting and deploying DHIS 2 with an encrypted HTTPS protocol. This setting will enable e.g. secure cookies. HTTPS deployment is required when this setting is enabled.


### PR DESCRIPTION
If there is a tailing slash it can cause problems when running on a specific port for example
`server.base.url = https://example.com:8443/`
will in some cases make links go to https://example.com:8443/ where as 
`server.base.url = https://example.com:8443`
Will make sure to include the port.