### PR TITLE
docs: Clarifies the relationship between externalAccess and publicAccess

### DIFF
--- a/src/developer/web-api/sharing.md
+++ b/src/developer/web-api/sharing.md
@@ -78,6 +78,13 @@ curl -d @sharing.json "localhost/api/33/sharing?type=dataElement&id=fbfJHSPpUQD"
   -H "Content-Type:application/json" -u admin:district
 ```
 
+> **Note**
+>
+> It is possible to create illogical sharing combinations. For
+> instance, if `externalAccess` is set to `true` but `publicAccess` is
+> set to `--------`, then users will have access to the object 
+> ***only when they are logged out.***
+
 ## Cascade Sharing for Dashboard
 
 ### Overview

--- a/src/developer/web-api/sharing.md
+++ b/src/developer/web-api/sharing.md
@@ -80,10 +80,10 @@ curl -d @sharing.json "localhost/api/33/sharing?type=dataElement&id=fbfJHSPpUQD"
 
 > **Note**
 >
-> It is possible to create illogical sharing combinations. For
+> It is possible to create surprising sharing combinations. For
 > instance, if `externalAccess` is set to `true` but `publicAccess` is
 > set to `--------`, then users will have access to the object 
-> ***only when they are logged out.***
+> only when they are logged out.
 
 ## Cascade Sharing for Dashboard
 

--- a/src/developer/web-api/visualizations.md
+++ b/src/developer/web-api/visualizations.md
@@ -315,7 +315,7 @@ Table: Visualization attributes
 | percentStackedValues | Uses stacked values or not. More likely to be applied for graphics/charts. Boolean value. |
 | noSpaceBetweenColumns | Show/hide space between columns. Boolean value. |
 | regression | Indicates whether the Visualization contains regression columns. More likely to be applicable to Pivot/Report. Boolean value. |
-| externalAccess | Indicates whether the Visualization is available as external read-only. Boolean value. |
+| externalAccess | Indicates whether the Visualization is available as external read-only. Only applies when no user is logged in. Boolean value. |
 | userOrganisationUnit | Indicates if the user has an organisation unit. Boolean value. |
 | userOrganisationUnitChildren | Indicates if the user has a children organisation unit. Boolean value. |
 | userOrganisationUnitGrandChildren | Indicates if the user has a grand children organisation unit . Boolean value. |

--- a/src/user/about-sharing-of-objects.md
+++ b/src/user/about-sharing-of-objects.md
@@ -31,7 +31,9 @@ with everyone, including users which cannot logon to DHIS2. This is
 useful for sharing public resources with external systems. Note, that if
 objects are shared externally, then they are visible to anyone who has
 access to the URL which provides the resource without any login
-credentials.
+credentials. Also note that "External access" ***does not*** give access
+to logged in users—to give them access, you must also allow 
+"Public access".
 
 Next to "Public access" you can choose your public access option under
 "METADATA": "No access", "Can view only" or "Can edit and view", and

--- a/src/user/data-visualizer.md
+++ b/src/user/data-visualizer.md
@@ -316,8 +316,7 @@ Sharing settings can be accessed by clicking **File** \> **Share**. Change shari
 
 - **Can view only**: Can only view the visualization.
 
-- **No access**: Won't have access to the visualization. This
-  setting is only applicable to **Public access** and **External access**.
+- **No access**: Won't have access to the visualization. This setting is only applicable to **Public access** and **External access**. (Note that to enable access to everyone, both **Public access** and **External access** must be set to allow view.)
 
 New users can be added by searching for them by name under `Add users and user groups`.
 

--- a/src/user/manage-users-user-roles-and-user-groups.md
+++ b/src/user/manage-users-user-roles-and-user-groups.md
@@ -493,6 +493,9 @@ just a password.
     plus icon. The user group is added to the list.
 
 4.  (Optional) Select **External access (without login)**.
+    
+    Note that this only gives access when no user is logged in.  To give
+    access also to logged in users, you must also allow **Public access**.
 
 5.  Change the settings for the user groups you want to modify.
  - **None**
@@ -575,6 +578,9 @@ just a password.
     plus icon. The user group is added to the list.
 
 4.  (Optional) Select **External access (without login)**.
+    
+    Note that this only gives access when no user is logged in.  To give
+    access also to logged in users, you must also allow **Public access**.
 
 5.  Change the settings for the user groups you want to modify.
  - **None**

--- a/src/user/managing-dashboards.md
+++ b/src/user/managing-dashboards.md
@@ -348,7 +348,12 @@ All dashboards have two sharing groups set by default.
   external resource through the API. This is useful for when you are creating an
   external web portal but would like to call information from a
   dashboard you have made internally within DHIS2. By default, this
-  option is not selected. For more information, see [Viewing analytical resource representations](https://docs.dhis2.org/master/en/developer/html/webapi_viewing_analytical_resource_representations.html#) in the developer guide.
+  option is not selected.
+
+  Note that in order for users to see this dashboard through the API while
+  logged in, public access must also allow viewing.
+  
+  For more information, see [Viewing analytical resource representations in the developer guide](https://docs.dhis2.org/en/full/develop/dhis-core-version-master/developer-manual.html#webapi_viewing_analytical_resource_representations).
 
 - Public access (with login)
 

--- a/src/user/using-the-maps-app.md
+++ b/src/user/using-the-maps-app.md
@@ -1488,6 +1488,9 @@ everyone or a user group. To modify the sharing settings:
     Repeat the step to add more user groups.
 
 3.  If you want to allow external access, select the corresponding box.
+    
+    Note that in order for logged in and not logged in users to have
+    access, you must also allow public access.
 
 4.  For each user group, choose an access setting. The options are:
 


### PR DESCRIPTION
As discussed in [Jira 11848](https://jira.dhis2.org/browse/DHIS2-11848), it is possible to set up externalAccess and publicAccess to provide access to objects only when no user is logged in (and prevent access when a user is logged in).

This seemed like a good thing to mention in the documentation, so I added it everywhere that externalAccess is mentioned.