### PR TITLE
feat: Support for new flag skipOrgUnitOwnership [DHIS2-13873]

### DIFF
--- a/src/developer/web-api/maintenance.md
+++ b/src/developer/web-api/maintenance.md
@@ -32,6 +32,7 @@ Table: Analytics tables optional query parameters
 | skipAggregate | false &#124; true | Skip generation of aggregate data and completeness data |
 | skipEvents | false &#124; true | Skip generation of event data |
 | skipEnrollment | false &#124; true | Skip generation of enrollment data |
+| skipOrgUnitOwnership | false &#124; true | Skip generation of organization unit ownership data |
 | lastYears | integer | Number of last years of data to include |
 
 "Data Quality" and "Data Surveillance" can be run through the monitoring


### PR DESCRIPTION
Documenting the new query parameter flag that can be set in the Analytics Export job.
The endpoint related to that job is `/api/resourceTables/analytics`

Example of usage:
`/api/resourceTables/analytics?skipOrgUnitOwnership=true`