### PR TITLE
docs: new orgUnitField options DHIS2-11597

### DIFF
--- a/src/developer/web-api/analytics.md
+++ b/src/developer/web-api/analytics.md
@@ -53,8 +53,8 @@ Table: Query parameters
 | rows | No | Dimensions to use as rows for table layout. | Any dimension (must be query dimension) |
 | order | No | Specify the ordering of rows based on value. | ASC &#124; DESC |
 | timeField | No | The time field to base event aggregation on. Applies to event data items only. Can be a predefined option or the ID of an attribute or data element with a time-based value type. | EVENT_DATE &#124; ENROLLMENT_DATE &#124; INCIDENT_DATE &#124; DUE_DATE &#124; COMPLETED_DATE &#124; CREATED &#124; LAST_UPDATED &#124; <Attribute ID\> &#124; <Data element ID\> |
-| orgUnitField | No | The organisation unit field to base event aggregation on. Applies to event data items only. Can be the ID of an attribute or data element with the Organisation unit value type. The default option is specified as omitting the query parameter. <Attribute ID\> &#124; <Data element ID\> | <Attribute ID\> &#124; <Data element ID\> |
-| enhancedConditions           | No       | Enable enhanced conditions for dimensions/filters | false&#124;true |
+| orgUnitField | No | The organisation unit field to base event aggregation on. Applies to event data items only. Can be the ID of an attribute or data element with the Organisation unit value type. The default option is specified as omitting the query parameter. | <Attribute ID\> &#124; <Data element ID\> &#124; REGISTRATION &#124; ENROLLMENT &#124; OWNER_AT_START &#124; OWNER_AT_END |
+| enhancedConditions           | No       | Enable enhanced conditions for dimensions/filters | false &#124; true |
 
 The *dimension* query parameter defines which dimensions should be
 included in the analytics query. Any number of dimensions can be
@@ -840,7 +840,8 @@ Table: Query parameters for aggregate event analytics only
 | skipData | No | Exclude the data part of the response. | false &#124; true |
 | skipRounding | No | Skip rounding of aggregate data values. | false &#124; true |
 | aggregateData | No | Produce aggregate values for the data dimensions (as opposed to dimension items). | false &#124; true |
-| orgUnitField | No | The organisation unit field to base event aggregation on. Applies to event data items only. Can be the ID of an attribute or data element with the Organisation unit value type. The default option is specified as omitting the query parameter. <Attribute ID\> &#124; <Data element ID\> | <Attribute ID\> &#124; <Data element ID\> |
+| orgUnitField | No | The organisation unit field to base event aggregation on. Applies to event data items only. Can be the ID of an attribute or data element with the Organisation unit value type. The default option is specified as omitting the query parameter. | <Attribute ID\> &#124; <Data element ID\> &#124; REGISTRATION &#124; ENROLLMENT &#124; OWNER_AT_START &#124; OWNER_AT_END |
+
 
 
 
@@ -1291,6 +1292,17 @@ of value type organisation unit you can use the `orgUnitField` parameter:
     /api/analytics/events/aggregate/eBAyeGv0exc.json?dimension=ou:ImspTQPwCqd
       &dimension=pe:THIS_YEAR&dimension=oZg33kd9taw&stage=Zj7UnCAulEk
       &orgUnitField=S33cRBsnXPo
+
+The `orgUnitField` parameter value may be one of the following:
+
+| orgUnitField | Description |
+| --- | --- |
+| <Attribute ID\> | ID of an attribute with the organisation unit value type |
+| <Data element ID\> | ID of a data element with the organisation unit value type |
+| REGISTRATION | The organization unit at which the tracked entity instance was registered (created) |
+| ENROLLMENT | The organization unit at which the tracked entity instance was enrolled in the program |
+| OWNER_AT_START | The tracked entity instance's owning organisation unit at the start of the reporting period |
+| OWNER_AT_END | The tracked entity instance's owning organisation unit at the end of the reporting period |
 
 #### Ranges / legend sets
 


### PR DESCRIPTION
See [DHIS2-11597](https://dhis2.atlassian.net/browse/DHIS2-11597) including the comment from June 29, 2022. This documents the new options for orgUnitField: REGISTRATION, ENROLLMENT, OWNER_AT_START, and OWNER_AT_END.