### PR TITLE
feat: Update tracker documentation with potentialDuplicate request parameter [ DHIS2-14271 ]

### DIFF
--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -506,7 +506,7 @@ Table: Tracked entity instances query parameters
 | assignedUser | Filter the result down to a limited set of teis with events that are assigned to the given user IDs by using *assignedUser=id1;id2*.This parameter will be considered only if assignedUserMode is either PROVIDED or null. The API will error out, if for example, assignedUserMode=CURRENT and assignedUser=someId |
 | trackedEntityInstance | Filter the result down to a limited set of teis using explicit uids of the tracked entity instances by using *trackedEntityInstance=id1;id2*. This parameter will at the very least create the outer boundary of the results, forming the list of all teis using the uids provided. If other parameters/filters from this table are used, they will further limit the results from the explicit outer boundary. |
 | includeDeleted | Indicates whether to include soft deleted teis or not. It is false by default. |
-| potentialDuplicate | Filter the result based on the fact that a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
+| potentialDuplicate | Filter the result based on the fact that a TEI is a Potential Duplicate. true: return TEIs flagged as Potential Duplicates. false: return TEIs NOT flagged as Potential Duplicates. If omitted, we don't check whether a TEI is a Potential Duplicate or not.|
 
 The available organisation unit selection modes are explained in the
 following table.
@@ -805,7 +805,7 @@ Table: Tracked entity instances query parameters
 | assignedUserMode | Restricts result to tei with events assigned based on the assigned user selection mode, can be CURRENT &#124; PROVIDED &#124; NONE &#124; ANY. |
 | assignedUser | Filter the result down to a limited set of teis with events that are assigned to the given user IDs by using *assignedUser=id1;id2*.This parameter will be considered only if assignedUserMode is either PROVIDED or null. The API will error out, if for example, assignedUserMode=CURRENT and assignedUser=someId |
 | trackedEntityInstance | Filter the result down to a limited set of teis using explicit uids of the tracked entity instances by using *trackedEntityInstance=id1;id2*. This parameter will at the very least create the outer boundary of the results, forming the list of all teis using the uids provided. If other parameters/filters from this table are used, they will further limit the results from the explicit outer boundary. |
-| potentialDuplicate | Filter the result based on the fact that a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
+| potentialDuplicate | Filter the result based on the fact that a TEI is a Potential Duplicate. true: return TEIs flagged as Potential Duplicates. false: return TEIs NOT flagged as Potential Duplicates. If omitted, we don't check whether a TEI is a Potential Duplicate or not.|
 
 The available organisation unit selection modes are explained in the
 following table.

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -506,7 +506,7 @@ Table: Tracked entity instances query parameters
 | assignedUser | Filter the result down to a limited set of teis with events that are assigned to the given user IDs by using *assignedUser=id1;id2*.This parameter will be considered only if assignedUserMode is either PROVIDED or null. The API will error out, if for example, assignedUserMode=CURRENT and assignedUser=someId |
 | trackedEntityInstance | Filter the result down to a limited set of teis using explicit uids of the tracked entity instances by using *trackedEntityInstance=id1;id2*. This parameter will at the very least create the outer boundary of the results, forming the list of all teis using the uids provided. If other parameters/filters from this table are used, they will further limit the results from the explicit outer boundary. |
 | includeDeleted | Indicates whether to include soft deleted teis or not. It is false by default. |
-| potentialDuplicate | Indicates if a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
+| potentialDuplicate | Filter the result based on the fact that a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
 
 The available organisation unit selection modes are explained in the
 following table.
@@ -805,7 +805,7 @@ Table: Tracked entity instances query parameters
 | assignedUserMode | Restricts result to tei with events assigned based on the assigned user selection mode, can be CURRENT &#124; PROVIDED &#124; NONE &#124; ANY. |
 | assignedUser | Filter the result down to a limited set of teis with events that are assigned to the given user IDs by using *assignedUser=id1;id2*.This parameter will be considered only if assignedUserMode is either PROVIDED or null. The API will error out, if for example, assignedUserMode=CURRENT and assignedUser=someId |
 | trackedEntityInstance | Filter the result down to a limited set of teis using explicit uids of the tracked entity instances by using *trackedEntityInstance=id1;id2*. This parameter will at the very least create the outer boundary of the results, forming the list of all teis using the uids provided. If other parameters/filters from this table are used, they will further limit the results from the explicit outer boundary. |
-| potentialDuplicate | Indicates if a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
+| potentialDuplicate | Filter the result based on the fact that a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
 
 The available organisation unit selection modes are explained in the
 following table.

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -506,6 +506,7 @@ Table: Tracked entity instances query parameters
 | assignedUser | Filter the result down to a limited set of teis with events that are assigned to the given user IDs by using *assignedUser=id1;id2*.This parameter will be considered only if assignedUserMode is either PROVIDED or null. The API will error out, if for example, assignedUserMode=CURRENT and assignedUser=someId |
 | trackedEntityInstance | Filter the result down to a limited set of teis using explicit uids of the tracked entity instances by using *trackedEntityInstance=id1;id2*. This parameter will at the very least create the outer boundary of the results, forming the list of all teis using the uids provided. If other parameters/filters from this table are used, they will further limit the results from the explicit outer boundary. |
 | includeDeleted | Indicates whether to include soft deleted teis or not. It is false by default. |
+| potentialDuplicate | Indicates if a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
 
 The available organisation unit selection modes are explained in the
 following table.
@@ -804,6 +805,7 @@ Table: Tracked entity instances query parameters
 | assignedUserMode | Restricts result to tei with events assigned based on the assigned user selection mode, can be CURRENT &#124; PROVIDED &#124; NONE &#124; ANY. |
 | assignedUser | Filter the result down to a limited set of teis with events that are assigned to the given user IDs by using *assignedUser=id1;id2*.This parameter will be considered only if assignedUserMode is either PROVIDED or null. The API will error out, if for example, assignedUserMode=CURRENT and assignedUser=someId |
 | trackedEntityInstance | Filter the result down to a limited set of teis using explicit uids of the tracked entity instances by using *trackedEntityInstance=id1;id2*. This parameter will at the very least create the outer boundary of the results, forming the list of all teis using the uids provided. If other parameters/filters from this table are used, they will further limit the results from the explicit outer boundary. |
+| potentialDuplicate | Indicates if a tei is a Potential Duplicate. Can be true &#124; false or omitted. If omitted, we don't check whether a tei is a potentialDuplicate or not. |
 
 The available organisation unit selection modes are explained in the
 following table.


### PR DESCRIPTION
add _potentialDuplicate_ parameter to TEI requests. For the old tracker, this reflects for all GET endpoints and in the docs, it updates:
- /trackedEntityInstances
- /trackedEntityInstances/query (these endpoints create a grid)