### PR TITLE
DOCS: correct word is IP not UP (typo)

### DIFF
--- a/src/developer/web-api/overview.md
+++ b/src/developer/web-api/overview.md
@@ -165,6 +165,7 @@ you want the token to have if you plan on using PAT tokens in a non-secure and/o
 e.g. on a PC or server, you don't have 100% control over, or "embedded" in a webpage on another server.
 
 #### The different constraint types are as follows:
+
 * Expiry time
 * Allowed IP addresses
 * Allowed HTTP methods

--- a/src/developer/web-api/overview.md
+++ b/src/developer/web-api/overview.md
@@ -166,7 +166,7 @@ e.g. on a PC or server, you don't have 100% control over, or "embedded" in a web
 
 #### The different constraint types are as follows:
 * Expiry time
-* Allowed UP addresses
+* Allowed IP addresses
 * Allowed HTTP methods
 * Allowed HTTP referrers
 


### PR DESCRIPTION
Line 169, Changed typo "* Allowed UP addresses" to "* Allowed IP addresses"