### PR TITLE
docs: is(a in x,y,z) function DHIS2-14452

### DIFF
--- a/src/user/configure-metadata.md
+++ b/src/user/configure-metadata.md
@@ -1750,6 +1750,7 @@ Table: Indicator functions
 | Indicator Function | Arguments | Description |
 |---|---|---|
 | if | (boolean-expr, true-expr, false-expr) | Evaluates the boolean expression and if true returns the true expression value, if false returns the false expression value. The arguments must follow the rules for any indicator expression. |
+| is | (expr1 in expression [, expression ...]) | Returns true if expr1 is equal to any of the following expressions, otherwise false. |
 | isNull | (element) | Returns true if the element value is missing (null), otherwise false. |
 | isNotNull | (element) | Returns true if the element value is not missing (not null), otherwise false. |
 | firstNonNull | (element [, element ...]) | Returns the value of the first element that is not missing (not null). Can be provided any number of arguments. Any argument may also be a numeric or string literal, which will be returned if all the previous objects have missing values. |
@@ -2889,6 +2890,7 @@ Table: Validation Rule functions
 | Validation Rule Function | Arguments | Description |
 |---|---|---|
 | if | (boolean-expr, true-expr, false-expr) | Evaluates the boolean expression and if true returns the true expression value, if false returns the false expression value. The arguments must follow the rules for any indicator expression. |
+| is | (expr1 in expression [, expression ...]) | Returns true if expr1 is equal to any of the following expressions, otherwise false. |
 | isNull | (element) | Returns true if the element value is missing (null), otherwise false. |
 | isNotNull | (element) | Returns true if the element value is not missing (not null), otherwise false. |
 | firstNonNull | (element [, element ...]) | Returns the value of the first element that is not missing (not null). Can be provided any number of arguments. Any argument may also be a numeric or string literal, which will be returned if all the previous objects have missing values. |
@@ -4258,6 +4260,7 @@ sampled. For example:
         | Function | Means |
         |---|---|
         | if(test, valueIfTrue, valueIfFalse) | Evaluates **test** which is an expression that evaluates to a boolean value -- see **Boolean expression notes** below. If the test is **true**, returns the **valueIfTrue** expression. If it is **false**, returns the **valueIfFalse** expression. |
+        | is(expr1 in expression [, expression ...]) | Returns true if expr1 is equal to any of the following expressions, otherwise false. |
         | isNull(item) | Returns the boolean value **true** if the **item** is null (missing), otherwise returns **false**. The **item** can be any selected item from the right (data element, program data element, etc.). |
         | isNotNull(item) | Returns **true** if the **item** value is not missing (not null), otherwise **false**. |
         | firstNonNull(item [, item ...]) | Returns the value of the first **item** that is not missing (not null). Can be provided any number of arguments. Any argument may also be a numeric or string literal, which will be returned if all the previous items have missing values. |
@@ -4292,7 +4295,8 @@ sampled. For example:
         | sum(D{IpHINAT79UW.eMyVanycQSC}) / sum([days]) | Sum of all sampled values of data element eMyVanycQSC from porgram IpHINAT79UW divided by the number of days in all sample periods (resulting in the overall average daily value) |
         | sum(#{FTRrcoaog83}) + #{T7OyqQpUpNd} | Sum of all sampled values of data element FTRrcoaog83 plus the value of data element T7OyqQpUpNd in the period being predicted for (includes all disaggregations) |
         | 1.2 \* A{IpHINAT79UW.RKLKz1H20EE} | 1.2 times the value of attribute RKLKz1H20EE of program IpHINAT79UW, in the period being predicted for |
-        | if(isNull(#{T7OyqQpUpNd}), 0, 1) | If the data element T7OyqQpUpNd is null in the period being predicted, then 0, otherwise 1. |
+        | if(isNull(#{T7OyqQpUpNd}), 0, 1) | If the data element T7OyqQpUpNd is null in the period being predicted, then 0, otherwise 1 |
+        | if(is(#{jeiTh8ahyae} in 'NEGATIVE','UNKNOWN'), 0, 1) | If the data element jeiTh8ahyae has value 'NEGATIVE' or 'UNKNOWN' then 0, otherwise 1 |
         | percentileCont(0.5, #{T7OyqQpUpNd}) | Continuous 50th percentile of the sampled values for data element T7OyqQpUpNd. Note that this is the same as median(#{T7OyqQpUpNd}) |
         | if(count(#{T7OyqQpUpNd}) == 1, 0, stddevSamp(#{T7OyqQpUpNd})) | If there is one sample value present for data element T7OyqQpUpNd, then 0, otherwise the sample standard deviation of these sample values. (Note that if no samples are present then the stddevSamp returns no value, so no value is predicted.) |
         | #{T7OyqQpUpNd}.minDate(2022-10-1) | Value on or after 1-Oct-2022 |

--- a/src/user/configure-programs-in-the-maintenance-app.md
+++ b/src/user/configure-programs-in-the-maintenance-app.md
@@ -898,6 +898,7 @@ Table: Functions to use in a program indicator expression or filter
 | d2:countIfValue | (dataElement, value) | Useful only for enrollment program indicators. Counts the number of data values that matches the given literal value for the given program stage and data element in the course of the enrollment. The argument data element is supplied with the #{programStage.dataElement} syntax. The value can be a hard coded text or number, for example 'No_anemia' if only the values containing this text should be counted. |
 | d2:countIfCondition | (dataElement, condition) | Useful only for enrollment program indicators. Counts the number of data values that matches the given condition criteria for the given program stage and data element in the course of the enrollment. The argument data element is supplied with the #{programStage.dataElement} syntax. The condition is supplied as a expression in single quotes, for example '<10' if only the values less than 10 should be counted. |
 | if | (boolean-expr, true-expr, false-expr) | Evaluates the boolean expression and if true returns the true expression value, if false returns the false expression value. This is identical to the d2:condition function except that the boolean-expr is not quoted. |
+| is | (expr1 in expression [, expression ...]) | Returns true if expr1 is equal to any of the following expressions, otherwise false. |
 | isNull | (object) | Returns true if the object value is missing (null), otherwise false. |
 | isNotNull | (object) | Returns true if the object value is not missing (not null), otherwise false. |
 | firstNonNull | (object [, object ...]) | Returns the value of the first object that is not missing (not null). Can be provided any number of arguments. Any argument may also be a numeric or string literal, which will be returned if all the previous objects have missing values. |
@@ -913,6 +914,10 @@ A filter that uses the "hasValue" function looks like this:
 A filter that uses the "relationshipCount(relationshipTypeUid)" function looks like this:
 
     d2:relationshipCount('KLkjshoQ90U')
+
+A filter that uses the "is( x in y, z )" function looks like this:
+
+    is(#{oahc9ooVema} in 'New', 'Relapse')
 
 An expression that uses the "zing" and "oizp" functions looks like this:
 


### PR DESCRIPTION
See [DHIS2-14452](https://dhis2.atlassian.net/browse/DHIS2-14452). This documents the construct `is( a in x,y,z,...)` in indicators, validation rules, predictors, and program indicators.

[DHIS2-14452]: https://dhis2.atlassian.net/browse/DHIS2-14452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ