### PR TITLE
chore: Remove status from reportBundle field in report response [TECH-1524]

### DIFF
--- a/src/developer/web-api/new-tracker.md
+++ b/src/developer/web-api/new-tracker.md
@@ -851,7 +851,6 @@ For example, `TRACKED_ENTITY`:
 ```json
 {
   "bundleReport": {
-    "status": "OK",
     "typeReportMap": {
       "TRACKED_ENTITY": {
         "trackerType": "TRACKED_ENTITY",


### PR DESCRIPTION
There was a refactor around report in tracker and the status inside `bundleReport` was found to be redundant as it is always the same as the `status` in the root