### PR TITLE
feat: linked_accounts in dhis.conf

### DIFF
--- a/src/developer/web-api/users.md
+++ b/src/developer/web-api/users.md
@@ -429,6 +429,8 @@ GET /dhis-web-commons-security/logout.action?current={current_username}&switch={
 
 This has the effect of signing the current user out and signing in the new user, but it looks seamless as it is happening.
 
+Note that this API call will likely change in the future, but its general function will remain the same.
+
 To see a list of users that can be switched to, use this API call:
 
 ```

--- a/src/developer/web-api/users.md
+++ b/src/developer/web-api/users.md
@@ -419,6 +419,22 @@ you can use the *dataApprovalWorkflows* resource as follows:
 GET /api/users/{id}/dataApprovalWorkflows
 ```
 
+### Switching between user accounts connected to the same identity provider account
+
+If [linked accounts are enabled in dhis.conf](../../../manage/performing-system-administration/dhis-core-version-master/installation.html#connecting-a-single-identity-provider-account-to-multiple-dhis2-accounts) and a user has logged in via OIDC, then it is possible for the user to switch between accounts that are linked to the same identity provider account using this API call:
+
+```
+GET /dhis-web-commons-security/logout.action?current={current_username}&switch={username_to_switch_to}
+```
+
+This has the effect of signing the current user out and signing in the new user, but it looks seamless as it is happening.
+
+To see a list of users that can be switched to, use this API call:
+
+```
+GET /api/account/linkedAccounts
+```
+
 ## Current user information { #webapi_current_user_information } 
 
 In order to get information about the currently authenticated user and

--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -858,8 +858,7 @@ oidc.provider.google.ext_client.1.client_id = JWT_CLIENT_ID
 
 > **Note**
 >
-> See link for a separate tutorial for setting up Okta as a generic OIDC provider. 
-> [link](../tutorials/configure-oidc-with-okta.md)
+> [Check out our tutorial for setting up Okta as a generic OIDC provider.](../../../topics/tutorials/configure-oidc-with-okta.md)
 
 ### Connecting a single identity provider account to multiple DHIS2 accounts
 
@@ -873,6 +872,8 @@ The following `dhis.conf` section shows how to enable linked accounts.
 # Enable a single OIDC accounts to log in as one of several DHIS2 accounts
 linked_accounts.enabled = on
 ```
+
+For instructions on how to list linked accounts and switch between them, see [*Switching between user accounts connected to the same identity provider account* in the Users chapter of the developer documentation.](../../../develop/using-the-api/dhis-core-version-master/users.html#switching-between-user-accounts-connected-to-the-same-identity-provider-account)
 
 ## LDAP configuration { #install_ldap_configuration } 
 

--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -861,6 +861,19 @@ oidc.provider.google.ext_client.1.client_id = JWT_CLIENT_ID
 > See link for a separate tutorial for setting up Okta as a generic OIDC provider. 
 > [link](../tutorials/configure-oidc-with-okta.md)
 
+### Connecting a single identity provider account to multiple DHIS2 accounts
+
+DHIS2 has the ability to map a single identity provider account to multiple DHIS2 accounts. API calls are available to list the linked accounts and also switch between then.
+
+When this option is selected, the `openid` database field in the `userinfo` table does not need to be unique.  When presented with an `openid` value from the identity provider, DHIS2 will log in the user that most recently logged in.
+
+The following `dhis.conf` section shows how to enable linked accounts.
+
+```properties
+# Enable a single OIDC accounts to log in as one of several DHIS2 accounts
+linked_accounts.enabled = on
+```
+
 ## LDAP configuration { #install_ldap_configuration } 
 
 DHIS2 is capable of using an LDAP server for authentication of users.

--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -869,7 +869,7 @@ When this option is selected, the `openid` database field in the `userinfo` tabl
 The following `dhis.conf` section shows how to enable linked accounts.
 
 ```properties
-# Enable a single OIDC accounts to log in as one of several DHIS2 accounts
+# Enable a single OIDC account to log in as one of several DHIS2 accounts
 linked_accounts.enabled = on
 ```
 


### PR DESCRIPTION
Documenting a new dhis.conf variable: linked_accounts.enabled introduced with [DHIS2-7093](https://dhis2.atlassian.net/browse/DHIS2-7093)

[DHIS2-7093]: https://dhis2.atlassian.net/browse/DHIS2-7093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ