### PR TITLE
docs: rename whitelist to allowlist [DHIS2-10247]

### DIFF
--- a/src/developer/web-api/settings-and-configuration.md
+++ b/src/developer/web-api/settings-and-configuration.md
@@ -334,7 +334,7 @@ content-type, for instance:
 ["www.google.com", "www.dhis2.org", "www.who.int"]
 ```
 
-    GET POST /api/33/configuration/corsWhitelist
+    GET POST /api/33/configuration/corsAllowlist
 
 For POST requests, the configuration value should be sent as the request
 payload as text. The following table shows appropriate configuration
@@ -357,7 +357,7 @@ Table: Configuration values
 | remoteServerUrl | URL to remote server |
 | remoteServerUsername | Username for remote server authentication |
 | remoteServerPassword | Password for remote server authentication |
-| corsWhitelist | JSON list of URLs |
+| corsAllowlist | JSON list of URLs |
 
 As an example, to set the feedback recipients user group you can invoke
 the following curl command:

--- a/src/developer/web-api/settings-and-configuration.md
+++ b/src/developer/web-api/settings-and-configuration.md
@@ -326,8 +326,8 @@ resources:
     
     GET POST /api/facilityOrgUnitLevel
 
-For the CORS whitelist configuration you can make a POST request with an
-array of URLs to whitelist as payload using "application/json" as
+For the CORS allowlist configuration you can make a POST request with an
+array of URLs to allowlist as payload using "application/json" as
 content-type, for instance:
 
 ```json

--- a/src/user/system-settings.md
+++ b/src/user/system-settings.md
@@ -135,7 +135,7 @@ Table: Access settings
 | **Require user account password change** | Defines whether users should be forced to change their passwords every 3, 6 or 12 months.<br> <br>If you don't want to force users to change password, select **Never**. |
 | **Enable password expiry alerts** | When set, users will receive a notification when their password is about to expire. |
 | **Minimum characters in password** | Defines the minimum number of characters users must have in their passwords.<br> <br>You can select 8 (default), 10, 12 or 14. |
-| **CORS whitelist** | Whitelists a set of URLs which can access the DHIS2 API from another domain. Each URL should be entered on separate lines. Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources (e.g. javascript files) on a web page to be requested from another domain outside the domain from which the first resource was served. |
+| **CORS allowlist** | allowlists a set of URLs which can access the DHIS2 API from another domain. Each URL should be entered on separate lines. Cross-origin resource sharing (CORS) is a mechanism that allows restricted resources (e.g. javascript files) on a web page to be requested from another domain outside the domain from which the first resource was served. |
 
 ## Calendar settings { #system_calendar_settings } 
 


### PR DESCRIPTION
2 commits to rename whitelist to allowlist. 

The second commit, `935623b60c499d98b48547adeb66b01cd70a7539`, requires a new endpoint. And for consistency sake this should be done. However, of course, the PR cannot be merged until that is done (scheduled for discussion Jan 2nd) . This will PR will remain drafted until this is done, or the commit will be undone when its decided to not be changed.

Ticket: https://dhis2.atlassian.net/browse/DHIS2-10247

Backend change has been made: https://dhis2.atlassian.net/browse/DHIS2-16388, https://github.com/dhis2/dhis2-core/pull/16055