### PR TITLE
docs: Clarify that last years = 0 launches continuous/latest analytics

### DIFF
--- a/src/developer/web-api/maintenance.md
+++ b/src/developer/web-api/maintenance.md
@@ -35,6 +35,12 @@ Table: Analytics tables optional query parameters
 | skipOrgUnitOwnership | false &#124; true | Skip generation of organization unit ownership data |
 | lastYears | integer | Number of last years of data to include |
 
+> **Note**
+>
+> lastYears=0 means latest or continuous analytics, as defined in
+[Continuous analytics table](../../../use/user-guides/dhis-core-version-master/scheduling.html#scheduling_continuous_analytics_table).
+
+
 "Data Quality" and "Data Surveillance" can be run through the monitoring
 task, triggered with the following endpoint:
 

--- a/src/user/data-administration.md
+++ b/src/user/data-administration.md
@@ -360,7 +360,9 @@ re-process.
 
       - **Skip generation of organisation unit ownership data**
 
-3.  Select **Number of last years of data to include**.
+3.  Select **Number of last years of data to include**.  (If 0 is selected,
+then that will run latest or continuous analytics, as defined in
+[Continuous analytics table](scheduling.html#scheduling_continuous_analytics_table).)
 
 4.  Click **Start export**.
 

--- a/src/user/data-administration.md
+++ b/src/user/data-administration.md
@@ -361,7 +361,7 @@ re-process.
       - **Skip generation of organisation unit ownership data**
 
 3.  Select **Number of last years of data to include**.  (If 0 is selected,
-then that will run latest or continuous analytics, as defined in
+then you will run latest or continuous analytics, as defined in
 [Continuous analytics table](scheduling.html#scheduling_continuous_analytics_table).)
 
 4.  Click **Start export**.


### PR DESCRIPTION
@tomzemp suggested in [a PR for the Data Administration app](https://github.com/dhis2/data-administration-app/pull/1030) that the manual clarify what setting last years to 0 does.

I also found the place it's documented for the API where it wasn't clear, so I added some text there too.

@Philip-Larsen-Donnelly, I remember that you liked the notes to look a certain way—did I do it correctly in this PR?