### PR TITLE
docs: add tip on how to contribute custom checks to the core

### DIFF
--- a/src/developer/web-api/data-validation.md
+++ b/src/developer/web-api/data-validation.md
@@ -736,6 +736,14 @@ already completed details checks can be obtained using:
 Users of DHIS2 can now create and supply their own Data Integrity Checks. This can be useful if users
 want to avail of this functionality and extend upon the supplied set of core data integrity checks.
 
+> **Tip**
+> 
+> Users are also encouraged to share their custom checks with others by opening a pull request in the 
+> [dhis2-core](https://github.com/dhis2/dhis2-core) repository containing their `.yaml` file(s).
+> Please select `platform-backend` as reviewer to put the PR on our radar early on. The team will 
+> take care of checking and linking the check correctly, so it becomes part of the provided suite of 
+> checks with the next release. 
+
 An example of a custom check could be for determining if certain users are members of specific user groups.
 This type of check would be very specific to an implementation, and not generally applicable across all installs.
 These types of metadata checks can be used to extend the default checks which are included with DHIS2.


### PR DESCRIPTION
Upon request from Lars I added a section on the process to contribute checks to core as a user. 