### PR TITLE
clean: tracker docs

### DIFF
--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -1448,16 +1448,16 @@ Tracker export endpoints allow you to retrieve the previously imported objects w
 
 > **NOTE**
 >
-> - All tracker export endpoints default to a `JSON` response content. `CSV` is only supported 
+> * All tracker export endpoints default to a `JSON` response content. `CSV` is only supported 
 >   by tracked entities and events.
-> - You can export a CSV file by adding the `Accept` header ***text/csv*** or ***application/csv*** 
+> * You can export a CSV file by adding the `Accept` header ***text/csv*** or ***application/csv*** 
 >   to the request. 
-> - You can download in zip and gzip formats:
->   - CSV for Tracked entities 
->   - JSON and CSV for Events
-> - You can export a Gzip file by adding the `Accept` header ***application/csv+gzip*** for CSV 
+> * You can download in zip and gzip formats:
+>     *  CSV for Tracked entities 
+>     *  JSON and CSV for Events
+> * You can export a Gzip file by adding the `Accept` header ***application/csv+gzip*** for CSV 
 > or ***application/json+gzip*** for JSON.
-> - You can export a Zip file by adding the `Accept` header ***application/csv+zip*** for CSV or  
+> * You can export a Zip file by adding the `Accept` header ***application/csv+zip*** for CSV or  
 > ***application/json+zip*** for JSON.
 
 ### Common request parameters
@@ -1558,7 +1558,7 @@ The response is file `trackedEntities.csv.gz` containing the `trackedEntities.cs
 
 #### ZIP
 
-The response is `trackedEntities.csv.zip` file containing the `trackedEntities.csv` file.
+The response is file `trackedEntities.csv.zip` containing the `trackedEntities.csv` file.
 
 #### Tracked Entities Collection endpoint `GET /api/tracker/trackedEntities`
 
@@ -2119,12 +2119,12 @@ See [Events](#events) and [Data Values](#data-values) for more field description
 
 #### Events GZIP
 
-The response is `events.json.gz` or `events.csv.gzip` file containing the `events.json` 
+The response is file `events.json.gz` or `events.csv.gzip` containing the `events.json` 
 or `events.csv` file.
 
 #### Events ZIP
 
-The response is `events.json.gz` or `events.json.zip` file containing the `events.json` 
+The response is file`events.json.gz` or `events.json.zip` containing the `events.json` 
 or `events.csv` file.
 
 #### Events Collection endpoint `GET /api/tracker/events`


### PR DESCRIPTION
Following https://github.com/dhis2/dhis2-docs/pull/1357

- try to fix the [nested list](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html#webapi_nti_export) inside a blockquote that is not showing correctly. Not sure why `-` is in use for some lists. Markdown syntax [guide](https://confluence.atlassian.com/bitbucketserver/markdown-syntax-guide-776639995.html#Markdownsyntaxguide-Unorderedlist) would suggest `*`. Not sure also if this is an error that occurs when the docs are built. Currently, I am not able to use the https://github.com/dhis2/dhis2-docs-builder
- Fix misplaced `file` word 