### PR TITLE
docs: add documentation for wildcard routes api

### DIFF
--- a/src/developer/web-api/route.md
+++ b/src/developer/web-api/route.md
@@ -96,3 +96,24 @@ Custom authorities allows users that don't have the metadata access to manage th
   "authorities": ["MY_CUSTOM_APP"]
 }
 ```
+
+### Wildcard Routes
+
+It is possible to create "wildcard routes" which support sub-path requests which are then passed through to the upstream service.  To do this, the route URL must end with `/*`.  Sub-paths can then be specified by appending them after `/run`.
+
+```json
+{
+  "name": "postman-get-wildcard",
+  "code": "postman-get-wildcard",
+  "disabled": false,
+  "url": "https://postman-echo.com/*"
+}
+```
+
+After you have sent this to `/api/routes` you now have your route available
+for you, and can run it with its returned ID or you can also use code.  Note that
+the sub-path `/get` is passed in the URL of the request, which will trigger a request
+to `https://postman-echo.com/get`
+
+    GET /api/routes/ID/run/get
+    GET /api/routes/postman-get/run/get


### PR DESCRIPTION
This adds missing documentation for the wildcard subpaths feature of the Routes API