### PR TITLE
feat: add query alias docs

### DIFF
--- a/src/developer/web-api/query-alias.md
+++ b/src/developer/web-api/query-alias.md
@@ -53,7 +53,7 @@ Most clients will automatically follow this redirect, sending a follow-up GET re
 
 ### An example of client code which automatically falls back to query aliasing
 
-The following short code snippet (in javascript) takes the target path of an API endpoint and attempts to access it.  If the URI is too long (either over some arbitrary length limit or returning a `414 URI Too Long` error) then a query alias will be created, and used whenever that target is accessed by this client again.  If the query alias has expired it will be automatically recreated.
+The following short code snippet (in typescript) takes the target path of an API endpoint and attempts to access it.  If the URI is too long (either over some arbitrary length limit or returning a `414 URI Too Long` error) then a query alias will be created, and used whenever that target is accessed by this client again.  If the query alias has expired it will be automatically recreated.
 
 Note that this is a very contrived example and **should not be used in a production application**.  In the future, the App Runtime query engine will automatically perform this fallback logic so that the application developer doesn't need to worry about constructing too-long URIs.
 

--- a/src/developer/web-api/query-alias.md
+++ b/src/developer/web-api/query-alias.md
@@ -1,0 +1,145 @@
+# Query Alias
+
+## Query Alias { #webapi_query_alias }
+
+The Query Alias API is an **EXPERIMENTAL** feature which supports shortening of long DHIS2 REST API queries using a built-in URL shortening service.  This can be useful in situations where very long URL paths exceed the limit set by browsers or network relays (often resulting in an [HTTP 414 - URI Too Long](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414) error).  It is recommended to only use this query aliasing feature as a fallback when a 414 error is encountered.
+
+> Note that query aliasing only support GET targets
+
+An Alias is ephemeral and can be deleted by the server at any time.  It typically will persist for several hours, but this is not guaranteed.  When accessing an expired Alias URL, a `404 Not Found` error will be returned by the server.  If needed again, a new alias with the same target can be created.
+
+### Creating an Alias
+
+To create a new query alias, a POST request should be sent to the `/api/query/alias` endpoint with the following POST body, where `<target>` is the target Rest API path (starting with `/api/`).
+
+```
+{
+    "target": "/api/path/to/long/rest/endpoint?withQuery=true&id=123456789"
+}
+```
+
+The return value will look something like this:
+
+```
+{
+    "id": "689a368a3f23e0985558eb4cff63e7fb4e63d736",
+    "path": "/api/query/alias/689a368a3f23e0985558eb4cff63e7fb4e63d736",
+    "href": "https://my-dhis2-instance.com/api/query/alias/689a368a3f23e0985558eb4cff63e7fb4e63d736",
+    "target": "/api/path/to/long/rest/endpoint?withQuery=true&id=123456789"
+}
+```
+
+### Accessing a previously-created Alias
+
+Once an alias has been created, it can be accessed via the relative `path` or absolute `href` URI found in the response body.  The relative path will be of the form `/api/query/alias/<md5hash>`, where `<md5hash>` is the md5 hash of the passed `target` path.  This ensures that query aliases are deterministic - the same target will always result in the same Alias.
+
+To access the `target` resource via a created Alias, a GET request can be sent to the Alias URI returned in the `href` response attribute.  For example:
+
+GET https://my-dhis2-instance.com/api/query/alias/689a368a3f23e0985558eb4cff63e7fb4e63d736
+
+The server will then respond as if the client had made a request directly to https://my-dhis2-instance.com/api/path/to/long/rest/endpoint?withQuery=true&id=123456789 (the target of the alias)
+
+
+### Creating and immediately accessing an Alias
+
+It is also possible to create an alias and, instead of parsing a JSON response, follow a `303 See Other` redirect to access the alias directly.  A `303 See Other` response is used instead of `302 Found` because following the redirect requires changing HTTP verb from POST (which creates the alias) to GET (which accesses the created alias)
+
+To create and immediately access an Alias, send a POST request the same JSON POST body payload including a `target` attribute to `/api/query/alias/redirect`.  The Alias will be created just as before, but a redirect HTTP response will be returned instead of an HTTP 200 success.
+
+HTTP 303 See Other
+Location: https://my-dhis2-instance.com/api/query/alias/689a368a3f23e0985558eb4cff63e7fb4e63d736
+
+Most clients will automatically follow this redirect, sending a follow-up GET request directly to https://my-dhis2-instance.com/api/query/alias/689a368a3f23e0985558eb4cff63e7fb4e63d736 and returning the response as if the original target had been accessed directly.  Note that some clients may not properly handle switching from POST to GET when encountering a `303 See Other`, which will result in a `501 Not Implemented` error.
+
+### An example of client code which automatically falls back to query aliasing
+
+The following short code snippet (in javascript) takes the target path of an API endpoint and attempts to access it.  If the URI is too long (either over some arbitrary length limit or returning a `414 URI Too Long` error) then a query alias will be created, and used whenever that target is accessed by this client again.  If the query alias has expired it will be automatically recreated.
+
+Note that this is a very contrived example and **should not be used in a production application**.  In the future, the App Runtime query engine will automatically perform this fallback logic so that the application developer doesn't need to worry about constructing too-long URIs.
+
+```ts
+type AliasRequest = {
+    target: string
+}
+
+type AliasResponse = {
+    id: string
+    path: string
+    href: string
+    target: string
+}
+
+type FetchResponse = {
+    status: number
+    data: AliasResponse
+}
+
+const BASE_URL = "https://my-dhis2-instance.com"
+const MAX_URI_LENGTH = 2000
+const ALIAS_API_PATH = 'api/query/alias'
+
+const cachedAliases: Record<string, AliasResponse> = {}
+
+const joinPath = (...segments: string[]) => {
+    const firstPart = segments.shift()?.replace(/^\//, '')
+
+    return segments.reduce((parts, segment) => {
+        segment = segment.replace(/^\//, '').replace(/\/$/, '')
+        return parts.concat(segment.split('/'))
+    }, [firstPart]).join('/')
+}
+
+const fetchDHIS2 = async (path: string, init?: RequestInit): Promise<FetchResponse> => {
+    const response = await fetch(joinPath(BASE_URL, path), {
+        ...init
+    })
+    return {
+        status: response.status,
+        data: (response.status == 200) ? await response.json() : undefined
+    }
+}
+
+const createAlias = async (path: string) => {
+    const body: AliasRequest = {
+        target: path
+    }
+    return await fetchDHIS2(ALIAS_API_PATH, {
+        method: 'POST',
+        body: JSON.stringify(body)
+    })
+}
+
+const fetchDHIS2WithAliasFallback = async (path: string, init?: RequestInit, recreateOnFailure = true): Promise<FetchResponse> => {
+    const uri = joinPath(BASE_URL, path)
+    const alias = cachedAliases[path]
+
+    if (alias) {
+        const response = await fetchDHIS2(alias.path)
+        if (response.status === 404 && recreateOnFailure) {
+            delete cachedAliases[path];
+            return fetchDHIS2WithAliasFallback(path, init, false)
+        }
+        return response;
+    }
+
+    if (uri.length >= MAX_URI_LENGTH) {
+        const response = await createAlias(path);
+        if (response.status === 201) {
+            cachedAliases[path] = response.data
+        }
+        return fetchDHIS2WithAliasFallback(path, init, false)
+    }
+
+    const response = await fetchDHIS2(path, init)
+    if (response.status === 414) {
+        const response = await createAlias(path);
+        if (response.status === 201) {
+            cachedAliases[path] = response.data
+        }
+        return fetchDHIS2WithAliasFallback(path, init, false)
+    }
+
+    return response
+}
+export default fetchDHIS2WithAliasFallback
+```

--- a/src/developer/web-api/route.md
+++ b/src/developer/web-api/route.md
@@ -97,14 +97,17 @@ Custom authorities allows users that don't have the metadata access to manage th
 }
 ```
 
+    POST /api/routes/ID/run
+      { "answer": 42 }
+
 ### Wildcard Routes
 
 It is possible to create "wildcard routes" which support sub-path requests which are then passed through to the upstream service.  To do this, the route URL must end with `/*`.  Sub-paths can then be specified by appending them after `/run`.
 
 ```json
 {
-  "name": "postman-get-wildcard",
-  "code": "postman-get-wildcard",
+  "name": "postman-wildcard",
+  "code": "postman-wildcard",
   "disabled": false,
   "url": "https://postman-echo.com/*"
 }
@@ -112,8 +115,10 @@ It is possible to create "wildcard routes" which support sub-path requests which
 
 After you have sent this to `/api/routes` you now have your route available
 for you, and can run it with its returned ID or you can also use code.  Note that
-the sub-path `/get` is passed in the URL of the request, which will trigger a request
-to `https://postman-echo.com/get`
+the sub-paths `/get` and `/post` are passed in the URL of the request below, which will trigger requests to `https://postman-echo.com/get` and `https://postman-echo.com/post` respectively.
 
     GET /api/routes/ID/run/get
-    GET /api/routes/postman-get/run/get
+    GET /api/routes/postman-wildcard/run/get
+
+    POST /api/routes/ID/run/post
+    POST /api/routes/postman-wildcard/run/post


### PR DESCRIPTION
Adds docs for the [v41 Query Alias feature](https://dhis2.atlassian.net/issues/DHIS2-14594?jql=text%20~%20%22query%20alias%2A%22)

I'm not sure if the typescript example is appropriate or will render properly...

Also included some minor fixes for the Routes API documentation