### PR TITLE
docs: old tracker has been removed from sync DHIS2-16564

### DIFF
--- a/src/developer/web-api/tracker-old.md
+++ b/src/developer/web-api/tracker-old.md
@@ -12,7 +12,10 @@
 > * `GET/POST/PUT/DELETE /api/events`
 > * `GET/POST/PUT/DELETE /api/relationships`
 >
-> will be removed in version **42**!
+> have been removed in version **42**!
+>
+> We also removed the ability to sync Tracker data via [metadata
+> sync](../../user/configure-metadata-synchronizing.md).
 >
 > * If you plan to use the tracker endpoints use the new endpoints described in
 >   [Tracker](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker.html)

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -19,7 +19,7 @@
 > * `GET/POST/PUT/DELETE /api/events`
 > * `GET/POST/PUT/DELETE /api/relationships`
 >
-> The deprecated endpoints will be removed in version **42**!
+> which have been removed in version **42**!
 >
 > [Migrating to new tracker
 > endpoints](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/tracker-deprecated.html#webapi_tracker_migration)

--- a/src/user/configure-metadata-synchronizing.md
+++ b/src/user/configure-metadata-synchronizing.md
@@ -15,13 +15,12 @@ local instances.
 If metadata creation and update take place at the central system and if
 the metadata synchronisation task is enabled, the metadata gets
 synchronized down to all the local instances which are bound to the
-central instance. These local instances will in turn push data values,
-Event and Tracker program data and complete data registration sets to
-the central instance. Enabling or disabling versioning of metadata
-synchronization at local instance, will not hinder the metadata
-synchronization process. This is because the metadata synchronization
-interacts with versioning end points of the central instance and not
-with end points of the local instance.
+central instance. These local instances will in turn push data values
+and complete data registration sets to the central instance. Enabling or
+disabling versioning of metadata synchronization at local instance, will
+not hinder the metadata synchronization process. This is because the
+metadata synchronization interacts with versioning end points of the
+central instance and not with end points of the local instance.
 
 Each snapshot of metadata export generated is referred to a metadata
 version. A new metadata version contains only the changes between the


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/DHIS2-16564

In v42 we have removed "old" tracker endpoints

- GET/POST/PUT/DELETE /api/trackedEntityInstance
- GET/POST/PUT/DELETE /api/enrollments
- GET/POST/PUT/DELETE /api/events
- GET/POST/PUT/DELETE /api/relationships

and all code that provides them including code syncing tracker data in https://docs.dhis2.org/en/use/user-guides/dhis-core-version-241/exchanging-data/metadata-synchronization.html#about-data-and-metadata-synchronization