### PR TITLE
DOCS: Include API request to reset login page back to default

### DIFF
--- a/src/developer/web-api/settings-and-configuration.md
+++ b/src/developer/web-api/settings-and-configuration.md
@@ -565,3 +565,9 @@ The appearance of the login dialog can also be modified by defining css variable
 --form-title-font-weight
 --form-container-title-color
 ```
+
+You can reset the login page theme using the API by making a *POST* request to ```/api/41/systemSettings/loginPageLayout``` including the loginPageLayout DEFAULT or SIDEBAR value in the request body, where content type is set to "text/plain". As an example, you can use curl like this:
+
+```bash
+curl "play.im.dhis2.org/stable-2-41-0/api/41/systemSettings/loginPageLayout" -d "DEFAULT" -H "Content-Type: text/plain" -u admin:district
+```


### PR DESCRIPTION
Including an API request to change loginPageLayout so that in the case that it's not possible to login using the custom theme, admin has the option to reset back to DEFAULT or SIDEBAR. Read more here: https://community.dhis2.org/t/login-custom-theme-v41-forgot-to-add-login-box/58993