### PR TITLE
Update tracker change log documentation [DHIS2-16741]

### DIFF
--- a/src/developer/web-api/audit.md
+++ b/src/developer/web-api/audit.md
@@ -34,67 +34,6 @@ Example: Get audits for data element `BOSZApCrBni`, org unit `DiszpKrYNg8` and c
 
     /api/33/audits/dataValue?de=BOSZApCrBni&ou=DiszpKrYNg8&co=TkDhg29x18A
 
-### Tracked entity data value audits { #webapi_tracked_entity_data_value_audits }
-
-The endpoint for tracked entity data value audits is located at:
-
-```
-/api/audits/trackedEntityDataValue
-```
-
-Table: Tracked entity data value query parameters
-
-| Parameter | Option | Description |
-|---|---|---|
-| de | Data element ID | One or more data element identifiers |
-| ou | Organisation unit ID | One or more organisation unit identifiers of the audited event |
-| events | Events ID | One or more event identifiers of the audited event (comma separated) |
-| ps | Program stage ID | One or more program sages of the audit event program |
-| startDate | Start date | Return only audit records created after date |
-| endDate | End date | Return only audit records created before date |
-| ouMode | Organisation unit selection mode | SELECTED \| DESCENDANTS |
-| auditType | UPDATE &#124; DELETE | Filter by one or more audit types |
-| skipPaging | false &#124; true | Turn paging on / off |
-| paging | false \| true | Whether to enable or disable paging |
-| page | Number | Page number (default 1) |
-| pageSize | Number | Page size (default 50) |
-
-Example: Get audits for data elements `eMyVanycQSC` and `qrur9Dvnyt5`:
-
-    /api/33/audits/trackedEntityDataValue?de=eMyVanycQSC&de=qrur9Dvnyt5
-
-Example: Get audits for org unit `O6uvpzGd5pu` including descendant org units in the org unit hierarchy:
-
-    /api/audits/trackedEntityDataValue?ou=O6uvpzGd5pu&ouMode=DESCENDANTS
-
-### Tracked entity attribute value audits { #webapi_tracked_entity_attribute_value_audits }
-
-The endpoint for tracked entity attribute value audits is located at:
-
-```
-/api/audits/trackedEntityAttributeValue
-```
-
-Table: Tracked entity attribute value query parameters
-
-| Parameter | Option | Description |
-|---|---|---|
-| tea | Tracked entity attribute ID | One or more tracked entity attribute identifiers |
-| trackedEntities | Tracked entity ID | One or more tracked entity identifiers (comma separated) |
-| auditType | UPDATE &#124; DELETE | Filter by one or more audit types |
-| skipPaging | false &#124; true | Turn paging on / off |
-| paging | false \| true | Whether to enable or disable paging |
-| page | Number | Page number (default 1) |
-| pageSize | Number | Page size (default 50) |
-
-Example: Get audits for tracked entity attribute `VqEFza8wbwA`:
-
-    /api/33/audits/trackedEntityAttributeValue?tea=VqEFza8wbwA
-
-Example: Get audits for tracked entity instance `wNiQ2coVZ39` and audit type `DELETE`:
-
-    /api/33/audits/trackedEntityAttributeValue?trackedEntities=wNiQ2coVZ39&auditType=DELETE
-
 ### Tracked entity instance audits { #webapi_tracked_entity_instance_audits }
 
 Once auditing is enabled for tracked entities (by setting `allowAuditLog` of tracked entity types to `true`), all read and search operations are logged. The endpoint for accessing audit logs is located at:

--- a/src/developer/web-api/audit.md
+++ b/src/developer/web-api/audit.md
@@ -34,6 +34,70 @@ Example: Get audits for data element `BOSZApCrBni`, org unit `DiszpKrYNg8` and c
 
     /api/33/audits/dataValue?de=BOSZApCrBni&ou=DiszpKrYNg8&co=TkDhg29x18A
 
+### Tracked entity data value audits { #webapi_tracked_entity_data_value_audits }
+**deprecated for removal in version 43 use [tracked entity data value change log endpoint](https://github.com/dhis2/dhis2-docs/blob/master/src/developer/web-api/tracker.md#event-data-value-change-logs--webapi_event_data_value_change_logs-)**
+
+The endpoint for tracked entity data value audits is located at:
+
+```
+/api/audits/trackedEntityDataValue
+```
+
+Table: Tracked entity data value query parameters
+
+| Parameter | Option | Description |
+|---|---|---|
+| de | Data element ID | One or more data element identifiers |
+| ou | Organisation unit ID | One or more organisation unit identifiers of the audited event |
+| events | Events ID | One or more event identifiers of the audited event (comma separated) |
+| ps | Program stage ID | One or more program sages of the audit event program |
+| startDate | Start date | Return only audit records created after date |
+| endDate | End date | Return only audit records created before date |
+| ouMode | Organisation unit selection mode | SELECTED \| DESCENDANTS |
+| auditType | UPDATE &#124; DELETE | Filter by one or more audit types |
+| skipPaging | false &#124; true | Turn paging on / off |
+| paging | false \| true | Whether to enable or disable paging |
+| page | Number | Page number (default 1) |
+| pageSize | Number | Page size (default 50) |
+
+Example: Get audits for data elements `eMyVanycQSC` and `qrur9Dvnyt5`:
+
+    /api/33/audits/trackedEntityDataValue?de=eMyVanycQSC&de=qrur9Dvnyt5
+
+Example: Get audits for org unit `O6uvpzGd5pu` including descendant org units in the org unit hierarchy:
+
+    /api/audits/trackedEntityDataValue?ou=O6uvpzGd5pu&ouMode=DESCENDANTS
+
+### Tracked entity attribute value audits { #webapi_tracked_entity_attribute_value_audits }
+
+**deprecated for removal in version 43 use [tracked entity attribute change log endpoint](https://github.com/dhis2/dhis2-docs/blob/master/src/developer/web-api/tracker.md#tracked-entity-attribute-value-change-logs--webapi_tracker_attribute_change_logs-)**
+
+The endpoint for tracked entity attribute value audits is located at:
+
+```
+/api/audits/trackedEntityAttributeValue
+```
+
+Table: Tracked entity attribute value query parameters
+
+| Parameter | Option | Description |
+|---|---|---|
+| tea | Tracked entity attribute ID | One or more tracked entity attribute identifiers |
+| trackedEntities | Tracked entity ID | One or more tracked entity identifiers (comma separated) |
+| auditType | UPDATE &#124; DELETE | Filter by one or more audit types |
+| skipPaging | false &#124; true | Turn paging on / off |
+| paging | false \| true | Whether to enable or disable paging |
+| page | Number | Page number (default 1) |
+| pageSize | Number | Page size (default 50) |
+
+Example: Get audits for tracked entity attribute `VqEFza8wbwA`:
+
+    /api/33/audits/trackedEntityAttributeValue?tea=VqEFza8wbwA
+
+Example: Get audits for tracked entity instance `wNiQ2coVZ39` and audit type `DELETE`:
+
+    /api/33/audits/trackedEntityAttributeValue?trackedEntities=wNiQ2coVZ39&auditType=DELETE
+
 ### Tracked entity instance audits { #webapi_tracked_entity_instance_audits }
 
 Once auditing is enabled for tracked entities (by setting `allowAuditLog` of tracked entity types to `true`), all read and search operations are logged. The endpoint for accessing audit logs is located at:

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -2130,9 +2130,10 @@ An example of a json response:
 The response will be the same as the collection endpoint but referring to a single tracked
 entity, although it might have multiple rows for each attribute.
 
-#### Tracked entity attribute value change logs `GET /api/tracker/trackedEntities/{uid}/changeLogs`
+#### Tracked entity attribute value change logs { #webapi_tracker_attribute_change_logs }
+`GET /api/tracker/trackedEntities/{uid}/changeLogs`
 
-This endpoint retrieves change logs for a tracked entity's attribute values, showing all changes over time.
+This endpoint retrieves change logs for the attributes of a specific tracked entity. It returns a list of all tracked entity attributes that have changed over time for that entity.
 
 |Parameter|Type|Allowed values|
 |---|---|---|
@@ -2187,10 +2188,8 @@ An example of a json response:
 }
 ```
 
-The change log can be of three types:
-- `CREATE`: holds the single current value of the attribute.
-- `UPDATE`: shows the attribute's previous and current value.
-- `DELETE`: displays the attribute value before deletion.
+The change log type can be `CREATE`, `UPDATE`, or `DELETE`.
+`CREATE` and `DELETE` will always hold a single value: the former shows the current value, and the latter shows the value that was deleted. UPDATE will hold two values: the previous and the current.
 
 ### Enrollments (`GET /api/tracker/enrollments`)
 
@@ -2637,7 +2636,8 @@ The API supports CSV and JSON response for `GET /api/tracker/trackedEntities`
 The response will be the same as the collection endpoint but referring to a single event,
 although it might have multiple rows for each data element value.
 
-#### Event data value change logs `GET /api/tracker/events/{uid}/changeLogs`
+#### Event data value change logs { #webapi_event_data_value_change_logs }
+`GET /api/tracker/events/{uid}/changeLogs`
 
 This endpoint retrieves change logs for the data values of a specific event. It returns a list of all event data values that have changed over time for that particular event.
 
@@ -2709,10 +2709,8 @@ An example of a json response:
 }
 ```
 
-The change log can be of three types:
-- `CREATE`: holds the single current value of the attribute.
-- `UPDATE`: shows the attribute's previous and current value.
-- `DELETE`: displays the attribute value before deletion.
+The change log type can be `CREATE`, `UPDATE`, or `DELETE`.
+`CREATE` and `DELETE` will always hold a single value: the former shows the current value, and the latter shows the value that was deleted. UPDATE will hold two values: the previous and the current.
 
 
 ### Relationships (`GET /api/tracker/relationships`)

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -2132,7 +2132,7 @@ entity, although it might have multiple rows for each attribute.
 
 #### Tracked entity attribute value change logs `GET /api/tracker/trackedEntities/{uid}/changeLogs`
 
-This endpoint retrieves change logs for the attributes of a specific tracked entity. It returns a list of all tracked entity attributes that have changed over time for that entity.
+This endpoint retrieves change logs for a tracked entity's attribute values, showing all changes over time.
 
 |Parameter|Type|Allowed values|
 |---|---|---|
@@ -2187,8 +2187,10 @@ An example of a json response:
 }
 ```
 
-The change log type can be `CREATE`, `UPDATE`, or `DELETE`.
-`CREATE` and `DELETE` will always hold a single value: the former shows the current value, and the latter shows the value that was deleted. UPDATE will hold two values: the previous and the current.
+The change log can be of three types:
+- `CREATE`: holds the single current value of the attribute.
+- `UPDATE`: shows the attribute's previous and current value.
+- `DELETE`: displays the attribute value before deletion.
 
 ### Enrollments (`GET /api/tracker/enrollments`)
 
@@ -2707,8 +2709,10 @@ An example of a json response:
 }
 ```
 
-The change log type can be `CREATE`, `UPDATE`, or `DELETE`.
-`CREATE` and `DELETE` will always hold a single value: the former shows the current value, and the latter shows the value that was deleted. UPDATE will hold two values: the previous and the current.
+The change log can be of three types:
+- `CREATE`: holds the single current value of the attribute.
+- `UPDATE`: shows the attribute's previous and current value.
+- `DELETE`: displays the attribute value before deletion.
 
 
 ### Relationships (`GET /api/tracker/relationships`)

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -2130,6 +2130,66 @@ An example of a json response:
 The response will be the same as the collection endpoint but referring to a single tracked
 entity, although it might have multiple rows for each attribute.
 
+#### Tracked entity attribute value change logs `GET /api/tracker/trackedEntities/{uid}/changeLogs`
+
+This endpoint retrieves change logs for the attributes of a specific tracked entity. It returns a list of all tracked entity attributes that have changed over time for that entity.
+
+|Parameter|Type|Allowed values|
+|---|---|---|
+|path `/{uid}`|`String`|Tracked entity `UID`.|
+|`program`|`String`|Program `UID` (optional).|
+
+##### Tracked entity attribute value change logs response example
+
+An example of a json response:
+
+```json
+{
+   "pager":{
+      "page":1,
+      "pageSize":10
+   },
+   "changeLogs":[
+      {
+         "createdBy":{
+            "uid":"AIK2aQOJIbj",
+            "username":"tracker",
+            "firstName":"Tracker demo",
+            "surname":"User"
+         },
+         "createdAt":"2024-06-20T14:51:16.433",
+         "type":"UPDATE",
+         "change":{
+            "dataValue":{
+               "dataElement":"bx6fsa0t90x",
+               "previousValue":"true",
+               "currentValue":"false"
+            }
+         }
+      },
+      {
+         "createdBy":{
+            "uid":"AIK2aQOJIbj",
+            "username":"tracker",
+            "firstName":"Tracker demo",
+            "surname":"User"
+         },
+         "createdAt":"2024-06-20T14:50:32.966",
+         "type":"CREATE",
+         "change":{
+            "dataValue":{
+               "dataElement":"ebaJjqltK5N",
+               "currentValue":"0"
+            }
+         }
+      }
+   ]
+}
+```
+
+The change log type can be `CREATE`, `UPDATE`, or `DELETE`.
+`CREATE` and `DELETE` will always hold a single value: the former shows the current value, and the latter shows the value that was deleted. UPDATE will hold two values: the previous and the current.
+
 ### Enrollments (`GET /api/tracker/enrollments`)
 
 Two endpoints are dedicated to enrollments:
@@ -2574,6 +2634,82 @@ The API supports CSV and JSON response for `GET /api/tracker/trackedEntities`
 
 The response will be the same as the collection endpoint but referring to a single event,
 although it might have multiple rows for each data element value.
+
+#### Event data value change logs `GET /api/tracker/events/{uid}/changeLogs`
+
+This endpoint retrieves change logs for the data values of a specific event. It returns a list of all event data values that have changed over time for that particular event.
+
+|Parameter|Type|Allowed values|
+|---|---|---|
+|path `/{uid}`|`String`|Event `UID`.|
+
+##### Event data value change logs response example
+
+An example of a json response:
+
+```json
+{
+   "pager":{
+      "page":1,
+      "pageSize":10
+   },
+   "changeLogs":[
+      {
+         "createdBy":{
+            "uid":"AIK2aQOJIbj",
+            "username":"tracker",
+            "firstName":"Tracker demo",
+            "surname":"User"
+         },
+         "createdAt":"2024-06-20T15:43:36.342",
+         "type":"DELETE",
+         "change":{
+            "dataValue":{
+               "dataElement":"UXz7xuGCEhU",
+               "previousValue":"12"
+            }
+         }
+      },
+      {
+         "createdBy":{
+            "uid":"AIK2aQOJIbj",
+            "username":"tracker",
+            "firstName":"Tracker demo",
+            "surname":"User"
+         },
+         "createdAt":"2024-06-20T15:43:27.175",
+         "type":"CREATE",
+         "change":{
+            "dataValue":{
+               "dataElement":"UXz7xuGCEhU",
+               "currentValue":"12"
+            }
+         }
+      },
+      {
+         "createdBy":{
+            "uid":"AIK2aQOJIbj",
+            "username":"tracker",
+            "firstName":"Tracker demo",
+            "surname":"User"
+         },
+         "createdAt":"2024-06-20T14:51:16.433",
+         "type":"UPDATE",
+         "change":{
+            "dataValue":{
+               "dataElement":"bx6fsa0t90x",
+               "previousValue":"true",
+               "currentValue":"false"
+            }
+         }
+      }
+   ]
+}
+```
+
+The change log type can be `CREATE`, `UPDATE`, or `DELETE`.
+`CREATE` and `DELETE` will always hold a single value: the former shows the current value, and the latter shows the value that was deleted. UPDATE will hold two values: the previous and the current.
+
 
 ### Relationships (`GET /api/tracker/relationships`)
 


### PR DESCRIPTION
- Added the docs for the two new change log endpoints (data values and tracked entity attribute values).
- Marked the old endpoints in audit as deprecated and to be removed in v43.