### PR TITLE
fix: update wildcard route documentation

### DIFF
--- a/src/developer/web-api/route.md
+++ b/src/developer/web-api/route.md
@@ -102,14 +102,14 @@ Custom authorities allows users that don't have the metadata access to manage th
 
 ### Wildcard Routes
 
-It is possible to create "wildcard routes" which support sub-path requests which are then passed through to the upstream service.  To do this, the route URL must end with `/*`.  Sub-paths can then be specified by appending them after `/run`.
+It is possible to create "wildcard routes" which support sub-path requests which are then passed through to the upstream service.  To do this, the route URL must end with `/**`.  Sub-paths can then be specified by appending them after `/run`.
 
 ```json
 {
   "name": "postman-wildcard",
   "code": "postman-wildcard",
   "disabled": false,
-  "url": "https://postman-echo.com/*"
+  "url": "https://postman-echo.com/**"
 }
 ```
 


### PR DESCRIPTION
the docs for wildcard mentioned that the URL should end with an asterisk `*`, but it's supposed to end with _two_ asterisks `**` otherwise the subpath doesn't work. Here is the [line](https://github.com/dhis2/dhis2-core/blob/59a289f6de2aaaf33fb3e199f07af97eefe61964/dhis-2/dhis-api/src/main/java/org/hisp/dhis/route/Route.java#L51C55-L51C57) of code defining this behaviour: 