### PR TITLE
doc: fix typo

### DIFF
--- a/src/developer/web-api/users.md
+++ b/src/developer/web-api/users.md
@@ -345,7 +345,7 @@ with a *409 Conflict* status code together with a descriptive message.
 
 ### User login (Experimental) { #webapi_user_login }
 
-This endpoint is not meant for external use, unless you are implmenting a custom login app, which you probably should not do, unless you have a very good reason.
+This endpoint is not meant for external use, unless you are implementing a custom login app, which you probably should not do, unless you have a very good reason.
 
 A user can log in and get a session cookie with the following example:  
 `POST` `/api/auth/login`  


### PR DESCRIPTION
## Summary
Fixes a typo. The word implementing was spelled wrongly as 'implmenting'.