### PR TITLE
docs: remove DHIS2 Live from the docs.

### DIFF
--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -1,9 +1,8 @@
 # Installation { #installation } 
 
 The installation chapter provides information on how to install DHIS2 in
-various contexts, including online central server, offline local
-network, standalone application and self-contained package called DHIS2
-Live.
+various contexts, including online central server, and offline local
+network.
 
 ## Introduction { #install_introduction } 
 


### PR DESCRIPTION
The first paragraph mentions: "standalone application and self-contained package called DHIS2 Live" however, "DHIS2 Live" was deprecated a long time ago. Thanks!