### PR TITLE
docs: Analytics table hooks in the Maintenance App [DHIS2-13473]

### DIFF
--- a/src/developer/web-api/analytics.md
+++ b/src/developer/web-api/analytics.md
@@ -2886,6 +2886,8 @@ Table: Phases, table types and temporary tables
 
 ### Creating hooks { #webapi_create_analytics_table_hook } 
 
+You can create hooks with the Maintenance app or with the API.
+
 To create a hook which should run after the resource tables have been populated you can do a *POST* request like this using *JSON* as content type:
 
 ```

--- a/src/user/configure-metadata.md
+++ b/src/user/configure-metadata.md
@@ -5097,7 +5097,7 @@ View".
 The Analytics Table Hooks functionality of DHIS2 stores SQL code that
 is run during different phases of the analytics table generation process.
 
-See also [the documentation on <code>/api/analyticsTableHooks</code>](../../../develop/using-the-api/dhis-core-version-master/analytics.html#webapi_analytics_table_hooks).
+See also [the documentation on <code>/api/analyticsTableHooks</code> in the Develop section of the manual](../../../develop/using-the-api/dhis-core-version-master/analytics.html#webapi_analytics_table_hooks).
 
 ### Creating a new analytics table hook
 

--- a/src/user/configure-metadata.md
+++ b/src/user/configure-metadata.md
@@ -34,6 +34,12 @@ need to collect and analyze data:
 
   - External map layers
 
+  - SQL views
+
+  - Locales
+
+  - Analytics table hooks
+
 > **Note**
 >
 > The functions you have access to depend on your user role's access
@@ -4984,7 +4990,7 @@ cultural region.
 
 5.  Click **Save**.
 
-## Manage SQL Views { #maintenance_sql_view } 
+## Manage SQL views { #maintenance_sql_view } 
 
 The SQL View functionality of DHIS2 will store the SQL view definition
 internally, and then materialize the view when requested.
@@ -5086,7 +5092,7 @@ View".
 > appears after view B in alphabetical order, analytics may fail, as the
 > view with dependencies will not be dropped in the correct order.
 
-## Manage Analytics Table Hooks { #maintenance_analytics_table_hooks } 
+## Manage analytics table hooks { #maintenance_analytics_table_hooks } 
 
 The Analytics Table Hooks functionality of DHIS2 stores SQL code that
 is run during different phases of the analytics table generation process.

--- a/src/user/configure-metadata.md
+++ b/src/user/configure-metadata.md
@@ -5086,6 +5086,20 @@ View".
 > appears after view B in alphabetical order, analytics may fail, as the
 > view with dependencies will not be dropped in the correct order.
 
+## Manage Analytics Table Hooks { #maintenance_analytics_table_hooks } 
+
+The Analytics Table Hooks functionality of DHIS2 stores SQL code that
+is run during different phases of the analytics table generation process.
+
+See also [the documentation on <code>/api/analyticsTableHooks</code>](../../../develop/using-the-api/dhis-core-version-master/analytics.html#webapi_analytics_table_hooks).
+
+### Creating a new analytics table hook
+
+To create a new analytics table hook, click **Apps** \> **Maintenance**
+\> **Other** \> **Analytics table hooks** and click the Add **+** button.
+
+Press "Save" to store the analytics table hook.
+
 ## Manage Locales { #maintenance_locale_management } 
 
 It is possible to create custom locales in DHIS2. In addition to the


### PR DESCRIPTION
Adds basic documentation for analytics table hooks in the Maintenance section of the manual, pointing the reader to where to learn more.