### PR TITLE
docs: Change relative links to absolute links

### DIFF
--- a/src/developer/web-api/maintenance.md
+++ b/src/developer/web-api/maintenance.md
@@ -38,7 +38,7 @@ Table: Analytics tables optional query parameters
 > **Note**
 >
 > lastYears=0 means latest or continuous analytics, as defined in
-[Continuous analytics table](https://docs.dhis2.org/en/use/user-guides/dhis-core-version-master/maintaining-the-system/scheduling.html#scheduling_continuous_analytics_table).
+[Continuous analytics table](#scheduling_continuous_analytics_table).
 
 
 "Data Quality" and "Data Surveillance" can be run through the monitoring

--- a/src/developer/web-api/maintenance.md
+++ b/src/developer/web-api/maintenance.md
@@ -38,7 +38,7 @@ Table: Analytics tables optional query parameters
 > **Note**
 >
 > lastYears=0 means latest or continuous analytics, as defined in
-[Continuous analytics table](../../../use/user-guides/dhis-core-version-master/maintaining-the-system/scheduling.html#scheduling_continuous_analytics_table).
+[Continuous analytics table](https://docs.dhis2.org/en/use/user-guides/dhis-core-version-master/maintaining-the-system/scheduling.html#scheduling_continuous_analytics_table).
 
 
 "Data Quality" and "Data Surveillance" can be run through the monitoring

--- a/src/developer/web-api/users.md
+++ b/src/developer/web-api/users.md
@@ -541,7 +541,7 @@ GET /api/users/{id}/dataApprovalWorkflows
 
 ### Switching between user accounts connected to the same identity provider account
 
-If [linked accounts are enabled in dhis.conf](https://docs.dhis2.org/en/manage/performing-system-administration/dhis-core-version-master/installation.html#connecting-a-single-identity-provider-account-to-multiple-dhis2-accounts) and a user has logged in via OIDC, then it is possible for the user to switch between DHIS2 accounts that are linked to the same identity provider account using this API call:
+If [linked accounts are enabled in dhis.conf](#connecting-a-single-identity-provider-account-to-multiple-dhis2-accounts) and a user has logged in via OIDC, then it is possible for the user to switch between DHIS2 accounts that are linked to the same identity provider account using this API call:
 
 ```
 GET /dhis-web-commons-security/logout.action?current={current_username}&switch={username_to_switch_to}

--- a/src/developer/web-api/users.md
+++ b/src/developer/web-api/users.md
@@ -541,7 +541,7 @@ GET /api/users/{id}/dataApprovalWorkflows
 
 ### Switching between user accounts connected to the same identity provider account
 
-If [linked accounts are enabled in dhis.conf](../../../manage/performing-system-administration/dhis-core-version-master/installation.html#connecting-a-single-identity-provider-account-to-multiple-dhis2-accounts) and a user has logged in via OIDC, then it is possible for the user to switch between DHIS2 accounts that are linked to the same identity provider account using this API call:
+If [linked accounts are enabled in dhis.conf](https://docs.dhis2.org/en/manage/performing-system-administration/dhis-core-version-master/installation.html#connecting-a-single-identity-provider-account-to-multiple-dhis2-accounts) and a user has logged in via OIDC, then it is possible for the user to switch between DHIS2 accounts that are linked to the same identity provider account using this API call:
 
 ```
 GET /dhis-web-commons-security/logout.action?current={current_username}&switch={username_to_switch_to}

--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -1352,7 +1352,7 @@ Enables or disables execution of server-side program rules. This refers to progr
 system.remote_servers_allowed = https://server1.org/,https://server2.org/
 ```
 
-Sets the allowed list of servers to be called in relation to the [metadata pull](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/synchronization.html#webapi_sync_metadata_pull) functionality. It accepts comma-separated values, and it's recommended that each server end with a `/` for enhanced security. Default value is empty.
+Sets the allowed list of servers to be called in relation to the [metadata pull](#webapi_sync_metadata_pull) functionality. It accepts comma-separated values, and it's recommended that each server end with a `/` for enhanced security. Default value is empty.
 
 
 ## Reverse proxy configuration { #install_reverse_proxy_configuration } 

--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -1352,7 +1352,7 @@ Enables or disables execution of server-side program rules. This refers to progr
 system.remote_servers_allowed = https://server1.org/,https://server2.org/
 ```
 
-Sets the allowed list of servers to be called in relation to the [metadata pull](../developer/web-api/synchronization.md#webapi_sync_metadata_pull) functionality. It accepts comma-separated values, and it's recommended that each server end with a `/` for enhanced security. Default value is empty.
+Sets the allowed list of servers to be called in relation to the [metadata pull](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/synchronization.html#webapi_sync_metadata_pull) functionality. It accepts comma-separated values, and it's recommended that each server end with a `/` for enhanced security. Default value is empty.
 
 
 ## Reverse proxy configuration { #install_reverse_proxy_configuration } 

--- a/src/user/configure-metadata.md
+++ b/src/user/configure-metadata.md
@@ -5097,7 +5097,7 @@ View".
 The Analytics Table Hooks functionality of DHIS2 stores SQL code that
 is run during different phases of the analytics table generation process.
 
-See also [<code>/api/analyticsTableHooks</code> in the Developer documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/analytics.html#webapi_analytics_table_hooks).
+See also [<code>/api/analyticsTableHooks</code> in the Developer documentation](#webapi_analytics_table_hooks).
 
 ### Creating a new analytics table hook
 

--- a/src/user/configure-metadata.md
+++ b/src/user/configure-metadata.md
@@ -5097,7 +5097,7 @@ View".
 The Analytics Table Hooks functionality of DHIS2 stores SQL code that
 is run during different phases of the analytics table generation process.
 
-See also [<code>/api/analyticsTableHooks</code> in the Developer documentation](../../../develop/using-the-api/dhis-core-version-master/analytics.html#webapi_analytics_table_hooks).
+See also [<code>/api/analyticsTableHooks</code> in the Developer documentation](https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/analytics.html#webapi_analytics_table_hooks).
 
 ### Creating a new analytics table hook
 


### PR DESCRIPTION
In PR #1445, @jimgrace recommended that we consider absolute links instead of relative links in the documentation.  I have put together this PR to change the four relative links that I could find into absolute links.

One advantage of this approach is that it might work across more platforms.  For instance, if you're reading a PDF, the link would still work.  One disadvantage would be that it would switch the user between languages, from whatever language they are reading to English.

Maybe neither of these approaches makes sense, but it would be nice to have a way to link from one section of the documentation to another.

Requesting review from @Philip-Larsen-Donnelly, but I'm happy for you to pull in whoever else should be consulted.