### PR TITLE
feat: Fallback for User analysis org is referred to user capturing org [2.42-DHIS2-134982]

### DIFF
--- a/src/developer/web-api/analytics.md
+++ b/src/developer/web-api/analytics.md
@@ -318,12 +318,15 @@ below.
     above called "Date and period format" for the period format and
     available relative periods.
 
-  - For the organisation unit dimension, you can specify the items to be
-    the organisation unit or sub-units of the organisation unit
-    associated with the user currently authenticated for the request
-    using the keys `USER_ORGUNIT` or `USER_ORGUNIT_CHILDREN` as items,
-    respectively. You can also specify organisation unit identifiers
-    directly, or a combination of both.
+  - For the organization unit dimension, you can specify items as either
+    the organization unit or its sub-units associated with the currently
+    authenticated user. Use the keys USER_ORGUNIT for the organization unit
+    itself or USER_ORGUNIT_CHILDREN for its sub-units. You may also specify
+    organization unit identifiers directly or use a combination of both.
+    The authenticated user must have permission to export and analyze data
+    for the designated organization units. If no organization unit permissions
+    are explicitly granted, data capture and maintenance rights
+    will be applied instead.
 
   - For the organisation unit dimension, you can specify the organisation
     hierarchy level and the boundary unit to use for the request on the


### PR DESCRIPTION
For analytics operations the authenticated user must have permission to export and analyze data for the designated organization units. If no organization unit permissions are explicitly granted, data capture and maintenance rights will be applied instead.