### PR TITLE
 docs: Add user in search scope when granting temp access. [2.40]

### DIFF
--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -2126,16 +2126,15 @@ When requesting tracked entities without specifying a program, the response will
 
 #### Tracker Ownership Override: Break the Glass { #webapi_tracker_ownership_override }
 
-It is possible to temporarily override this ownership privilege for a
-program that is configured with an access level of *PROTECTED*. Any user
-will be able to temporarily gain access to the Program related data if
-the user specifies a reason for accessing the TrackedEntity-Program
-data. This act of temporarily gaining access is termed as *breaking the
-glass*. Currently, temporary access is granted for 3 hours. DHIS2
-audits breaking the glass along with the reason specified by the user.
-It is not possible to gain temporary access to a program that has been
-configured with an access level of *CLOSED*. To break the glass for a
-TrackedEntity-Program combination, the following POST request can be used:
+It is possible to temporarily override the ownership privilege for a program that is configured
+with an access level of *PROTECTED*. Any user with the org unit owner within their search scope, can
+temporarily access the program-related data by providing a reason for accessing it.
+
+This act of temporarily gaining access is termed *breaking the glass*.
+Currently, temporary access is granted for 3 hours. DHIS2 audits breaking the glass along with the
+reason specified by the user. It is not possible to gain temporary access to a program that has been
+configured with an access level of *CLOSED*.
+To break the glass for a TrackedEntity-Program combination, the following POST request can be used:
 
     /api/33/tracker/ownership/override?trackedEntityInstance=DiszpKrYNg8
       &program=eBAyeGv0exc&reason=patient+showed+up+for+emergency+care

--- a/src/developer/web-api/tracker.md
+++ b/src/developer/web-api/tracker.md
@@ -2134,6 +2134,7 @@ This act of temporarily gaining access is termed *breaking the glass*.
 Currently, temporary access is granted for 3 hours. DHIS2 audits breaking the glass along with the
 reason specified by the user. It is not possible to gain temporary access to a program that has been
 configured with an access level of *CLOSED*.
+
 To break the glass for a TrackedEntity-Program combination, the following POST request can be used:
 
     /api/33/tracker/ownership/override?trackedEntityInstance=DiszpKrYNg8


### PR DESCRIPTION
Add a user needs to have the org unit owner in the search scope to be able to break the glass.