### PR TITLE
Docs: Analytics - digit group seperator

### DIFF
--- a/src/user/system-settings.md
+++ b/src/user/system-settings.md
@@ -32,7 +32,7 @@ Table: Analytics settings
 |---|---|
 | **Default relative period for analysis** | Defines the relative period to use by default in analytics app: **Data Visualizer**, **Event Reports**, **Event Visualizer**, **GIS** and **Pivot Table** apps. The relative period will be automatically selected when you open these apps.<br> <br>Recommended setting: the most commonly used relative period among your users. |
 | **Property to display in analysis modules** | Sets whether you want to display the metadata objects' names or short names in the analytics apps: **Data Visualizer**, **Event Reports**, **Event Visualizer**, **GIS** and **Pivot Table** apps.<br> <br>The user can override this setting in the **Settings** app: **User settings** \> **Property to display in analysis modules**. |
-| **Default digit group separator to display in analysis modules** | Sets the default digit group separator in the analytics apps: **Data Visualizer**, **Event Reports**, **Event Visualizer**, **GIS** and **Pivot Table** apps. |
+| **Default digit group separator to display in analysis modules** | Sets the default digit group separator in the analytics apps: **Data Visualizer**, **Event Reports**, **Event Visualizer**, **GIS** and **Pivot Table** apps. Updating this system setting does not affect already saved visualizations. |
 | **Hide daily periods** | Hide daily periods in the analysis tools |
 | **Hide weekly periods** | Hide weekly periods in the analysis tools |
 | **Hide monthly periods** | Hide monthly periods in the analysis tools |


### PR DESCRIPTION
Added clarification to the digit group seperator. For more info, see CoP discussion thread: https://community.dhis2.org/t/digit-group-separator-setting-not-affecting-data-visualiser/63560/3


Added: "Updating this system setting does not affect already saved visualizations." (@janhenrikoverland)