### PR TITLE
docs: Remove system id from dhis conf

### DIFF
--- a/src/sysadmin/installation.md
+++ b/src/sysadmin/installation.md
@@ -1792,9 +1792,6 @@ server.https = off
 # System [Optional]
 # ----------------------------------------------------------------------
 
-# System identifier
-system.id = hmis1.country.org
-
 # System mode for database read operations only, can be 'off', 'on'
 system.read_only_mode = off
 

--- a/src/sysadmin/reference/dhis.conf.md
+++ b/src/sysadmin/reference/dhis.conf.md
@@ -93,9 +93,6 @@ server.https = off
 # System [Optional]
 # ----------------------------------------------------------------------
 
-# System identifier
-system.id = hmis1.country.org
-
 # System mode for database read operations only, can be 'off', 'on'
 system.read_only_mode = off
 


### PR DESCRIPTION
It is not possible to set the system ID through the use of `dhis.conf`, so removing it from the docs.

The system ID is configured on startup by retrieving the `systemid` column value from the `configuration` table.
If it is null, a random `UUID` is then assigned (see [ConfigurationPopulator](https://github.com/dhis2/dhis2-core/blob/bcf087c2d7f26a92056b67c3ca66f6c579792a40/dhis-2/dhis-services/dhis-service-core/src/main/java/org/hisp/dhis/startup/ConfigurationPopulator.java))

If a different value is required, it could be manually updated directly through the DB or through the configuration API (when a restart is required before the updated value can be seen).