### PR TITLE
doc: Add note on PR expression Date format should always be 'YYYY-MM-DD'

### DIFF
--- a/src/user/configure-programs-in-the-maintenance-app.md
+++ b/src/user/configure-programs-in-the-maintenance-app.md
@@ -1300,6 +1300,11 @@ date".
 
 ### Reference information: Operators and functions to use in program rule expression { #program_rules_operators_functions } 
 
+> **Note**
+>
+> When using absolute dates in program rule expressions, always use
+> 'YYYY-MM-DD' date format irrespective of the System Date format setting.
+
 > **Tip**
 >
 > You can nest functions within each other and with sub-expressions to


### PR DESCRIPTION
Arising from this https://dhis2.atlassian.net/browse/DHIS2-15951 , all absolute dates in program rule expressions should have the format 'YYYY-MM-DD' irrespective of the system date format setting. Adding a note in the documentation for this.