### PR TITLE
docs: drop obsolete Nginx directive from example

### DIFF
--- a/src/sysadmin/reference/reverse_proxy_nginx.md
+++ b/src/sysadmin/reference/reverse_proxy_nginx.md
@@ -148,7 +148,6 @@ http {
 	listen               443 ssl;
 	client_max_body_size 10M;
 
-	ssl                  on;
 	ssl_certificate      server.crt;
 	ssl_certificate_key  server.key;
 


### PR DESCRIPTION
The SSL directive is no longer supported and got an error when attempting to use it in the latest version of Nginx. See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl