### PR TITLE
docs: Remove skip individual analytics from program [DHIS2-20493]

### DIFF
--- a/src/user/configure-programs-in-the-maintenance-app.md
+++ b/src/user/configure-programs-in-the-maintenance-app.md
@@ -392,7 +392,6 @@ program. A program needs several types of metadata that you create in the **Main
 | Setting | Description |
 |---|---|
 | **Display in list** |                          Displays the value of this attribute in the list of tracked                         entity instances in Tracker capture.                      |
-| **Skip Individual Analytics** |                This attribute will not be included in the Tracker Analytics process; however, it will still be considered as part of the Aggregate Analytics process.                      |
 | **Mandatory** |                          The value of this attribute must be filled into data entry                         form before you can complete the event.                      |
 | **Date in future** |                          Will allow user to select a date in future for date                         attributes.                      |
 | **Mobile render type** |                          Can be used to select different render types for mobile                         devices. Available options vary depending on the attribute's                         value type. For example, for a numerical value you may                         select "Default", "Value",                         "Slider", "Linear scale", and                         "Spinner".                      |


### PR DESCRIPTION
I'm removing the docs on how to skip analytics on program, as we'll do in on the TEA level from now on.
There it's [already documented in OpenAPI](https://github.com/dhis2/dhis2-core/pull/22642/changes#diff-56efd8ae44f3e2ac31ff3e99856f9093560aec3ee73f11a8130c7afab738f821R122).