### PR TITLE
docs: fix OIDC login image config property names

### DIFF
--- a/src/sysadmin/reference/oauth.md
+++ b/src/sysadmin/reference/oauth.md
@@ -223,11 +223,11 @@ oidc.provider.helseid.extra_request_parameters = acr_values lvl4,other_key value
 # [Optional] This is the alias/name displayed on the login button in the DHIS2 login page
 oidc.provider.helseid.display_alias = HelseID
 
-# [Optional] Link to an url for a logo. (Can use absolute or relative URLs)
-oidc.provider.helseid.logo_image = ../security/btn_helseid.svg
+# [Optional] Link to a url for a logo. (Only relative paths are supported)
+oidc.provider.helseid.login_image = ../security/btn_helseid.svg
 
 # [Optional] CSS padding for the logo image
-oidc.provider.helseid.logo_image_padding = 0px 1px
+oidc.provider.helseid.login_image_padding = 0px 1px
 ```
 
 ## JWT bearer token authentication


### PR DESCRIPTION
## Summary
- Corrects `logo_image` → `login_image` and `logo_image_padding` → `login_image_padding` in the OIDC generic provider config example to match the actual DHIS2 config keys
- Clarifies that only relative paths are supported for the image URL (absolute paths are not supported)

