### PR TITLE
docs: correct DELETE response status code [DHIS2-17360]

### DIFF
--- a/src/developer/web-api/data-exchange.md
+++ b/src/developer/web-api/data-exchange.md
@@ -284,7 +284,7 @@ DELETE /api/aggregateDataExchanges/{id}
 ##### Response
 
 ```
-204 No Content
+200 OK
 ```
 
 ```json

--- a/src/developer/web-api/metadata.md
+++ b/src/developer/web-api/metadata.md
@@ -237,7 +237,7 @@ translations for the specific object and not just for a single locale
 (if not you will potentially overwrite existing locales for other
 locales).
 
-The status code will be `204 No Content` if the data value was successfully saved or updated, or `404 Not Found` if there was a validation error (e.g. more than one `SHORT_NAME` for the same `locale`).
+The status code will be `204 No Content` if the translations were successfully saved or updated, or `409 Conflict` if there was a validation error (e.g. more than one `SHORT_NAME` for the same `locale`).
 
 
 ### Web API versions { #webapi_api_versions } 

--- a/src/developer/web-api/metadata.md
+++ b/src/developer/web-api/metadata.md
@@ -638,7 +638,23 @@ request to the endpoint + id:
 curl -X DELETE -u user:password "http://server/api/constants/ID"
 ```
 
-A successful delete should return HTTP status 204 (no content).
+A successful delete returns HTTP status `200 OK` with a `WebMessage`
+response body wrapping an `ObjectReport` for the deleted object, for
+example:
+
+```json
+{
+  "httpStatus": "OK",
+  "httpStatusCode": 200,
+  "status": "OK",
+  "response": {
+    "responseType": "ObjectReport",
+    "uid": "abc123",
+    "klass": "org.hisp.dhis.constant.Constant",
+    "errorReports": []
+  }
+}
+```
 
 ### Adding and removing objects in collections { #webapi_adding_removing_objects_collections } 
 


### PR DESCRIPTION
## Summary

Corrects several inaccurate HTTP status codes documented for write operations on metadata objects. All verified against the code (`AbstractCrudController`) on supported versions (2.41, 2.42, 2.43, master).

### Changes

1. **`metadata.md` — "Deleting objects"**: docs said a successful `DELETE` returns `204 No Content`. It actually returns **`200 OK`** with a `WebMessage`/`ObjectReport` body (`AbstractCrudController.deleteObject` → `objectReport` → `ok()`), and has across all supported versions. Corrected the statement and added an example body. Enforced by tests (e.g. `LegendSetControllerTest` asserts `200`/`"OK"`).

2. **`data-exchange.md` — "Delete aggregate data exchange"**: response was labelled `204 No Content` while the example body right below already showed the `200 OK` `WebMessage`/`ObjectReport`. `AggregateDataExchangeController extends AbstractCrudController`, so its DELETE returns `200 OK` — corrected the label.

3. **`metadata.md` — translations (`PUT /api/{type}/{uid}/translations`)**: docs said a validation error returns `404 Not Found`. It actually returns **`409 Conflict`** — `TranslationsCheck` reports error `E1106` (e.g. duplicate property+locale) and `replaceTranslations` returns `objectReport(...)`, which resolves to a `409` `WebMessage`. The `204 No Content` success code was already correct here (this method sets `@ResponseStatus(NO_CONTENT)`). Also fixed the copy-paste "data value" wording. *(The equivalent statement in `i18n.md` already correctly says `409 Conflict`, so it's left unchanged.)*

## Reproduction (delete behaviour)

```
POST   /api/userGroups {"name":"..."}   -> 201 Created
DELETE /api/userGroups/{id}             -> 200 OK + WebMessage/ObjectReport body
```

Verified live on play dev.

## Notes

Documentation-only change. Returning real `204 No Content` for deletes would be a breaking API change across every metadata DELETE endpoint (and would drop the informative response body), so the docs are corrected to match the implementation rather than the other way around.

The reported programRules case (`DELETE /api/programRules/{id}`) is the same generic metadata-delete behaviour and is covered by change #1 — the programRules section itself makes no status-code claim, so no change is needed there.

Resolves [DHIS2-17360](https://dhis2.atlassian.net/browse/DHIS2-17360).

AI Assisted

[DHIS2-17360]: https://dhis2.atlassian.net/browse/DHIS2-17360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ