### PR TITLE
docs: fix metadata attribute value filter example for 2.42+

### DIFF
--- a/src/developer/web-api/metadata.md
+++ b/src/developer/web-api/metadata.md
@@ -325,11 +325,15 @@ query using the id property of the associated data element groups:
 
     /api/dataElements.json?filter=dataElementGroups.id:eq:qfxEYY9xAl6
 
-To get data elements with a particular attribute value for a metadata 
-attribute, a filter for the attribute ID and the attribute value can be 
-specified using the same collection query syntax:
+To get data elements with a particular value for a metadata attribute,
+use the attribute's ID as the property name in the filter:
 
-    /api/dataElements.json?filter=attributeValues.attribute.id:eq:n2xYlNbsfko&filter=attributeValues.value:eq:AFP
+    /api/dataElements.json?filter=n2xYlNbsfko:eq:AFP
+
+To get data elements which have any value for a metadata attribute, use
+the `!null` operator with the attribute's ID as the property name:
+
+    /api/dataElements.json?filter=n2xYlNbsfko:!null
 
 Get data elements which have any option set:
 


### PR DESCRIPTION
The metadata API filtering docs still show the pre-2.42 example:

```
/api/dataElements.json?filter=attributeValues.attribute.id:eq:n2xYlNbsfko&filter=attributeValues.value:eq:AFP
```

Since 2.42, metadata attribute values are stored as a JSONB map keyed by attribute ID (DHIS2-17482), so the `attributeValues.value` path no longer resolves and returns `400 E1003 Unknown path property`. The supported syntax uses the attribute's ID as the property name, which the same page already describes in the filter intro:

```
/api/dataElements.json?filter=n2xYlNbsfko:eq:AFP
```

This updates the example accordingly and adds an example for matching any value with `:!null`.

Reported on Slack by a community member hitting the 400 on v42+. Needs cherry-pick to `2.43` and `2.42`.

AI Assisted