### PR TITLE
docs: document period type label and displayLabel [DHIS2-20845]

### DIFF
--- a/src/developer/web-api/overview.md
+++ b/src/developer/web-api/overview.md
@@ -509,6 +509,104 @@ Table: Period format
 | Financial Year July | yyyyJuly | 2004July | July 2004-June 2005 |
 | Financial Year Oct | yyyyOct | 2004Oct | Oct 2004-Sep 2005 |
 
+### Period types { #webapi_period_types }
+
+The period types available in DHIS2 can be listed from the following
+resource:
+
+    GET /api/periodTypes
+
+The `fields` query parameter is supported and defaults to all fields.
+
+Table: Period type properties
+
+| Property | Description | Writable |
+|---|---|---|
+| name | Internal, hard-coded name of the period type, e.g. `FinancialFeb`. Identifies the period type. | No |
+| displayName | Translated, human-friendly name of the period type. | No |
+| isoDuration | Duration of the period type in ISO 8601 notation, e.g. `P1Y`. | No |
+| isoFormat | Format used for period identifiers of this type, as listed in the table above, e.g. `yyyyFeb`. | No |
+| frequencyOrder | Approximate number of days covered by the period type, used for ordering period types by frequency. | No |
+| label | Custom label for the period type. `null` when no custom label has been set. | Yes |
+| displayLabel | Label intended for display in client applications. Currently mirrors `label`. | No |
+
+An entry in the response looks like this:
+
+```json
+{
+  "name": "FinancialFeb",
+  "displayName": "Financial Year (February)",
+  "isoDuration": "P1Y",
+  "isoFormat": "yyyyFeb",
+  "frequencyOrder": 365,
+  "label": null,
+  "displayLabel": null
+}
+```
+
+#### Custom period type labels { #webapi_period_type_label }
+
+A period type can be given a custom label, which allows you to rename a
+period type across client applications, for example to present *Financial
+Year (February)* as *Academic Year (February)*. Client applications should
+render `displayLabel`, and fall back to `displayName` when no custom label
+has been set.
+
+Period types are predefined and cannot be created or deleted, so `POST` and
+`DELETE` are not supported. The `label` property is the only writable one;
+all other properties are immutable and are ignored if they are included in
+the request body.
+
+To set a label, send a PUT request containing the `name` of the period type
+to update and the new `label`. The period type is identified by `name` in
+the request body, not by a path parameter:
+
+    PUT /api/periodTypes
+
+```json
+{
+  "name": "FinancialFeb",
+  "label": "Academic Year (February)"
+}
+```
+
+A successful request returns:
+
+```json
+{
+  "status": "OK",
+  "message": "FinancialFeb updated successfully."
+}
+```
+
+The period type will then be returned with both `label` and `displayLabel`
+set:
+
+```json
+{
+  "name": "FinancialFeb",
+  "displayName": "Financial Year (February)",
+  "isoDuration": "P1Y",
+  "isoFormat": "yyyyFeb",
+  "frequencyOrder": 365,
+  "label": "Academic Year (February)",
+  "displayLabel": "Academic Year (February)"
+}
+```
+
+To remove a custom label, set `label` to an empty string:
+
+```json
+{
+  "name": "FinancialFeb",
+  "label": ""
+}
+```
+
+A request with a `name` which does not match an existing period type is
+rejected with `400 Bad Request` and the message *"FinancialFeb does not
+exist."*. Updating a period type label requires the `ALL` authority.
+
 ### Relative Periods { #webapi_date_relative_period_values } 
 
 In some parts of the API, like for the analytics resource, you can

--- a/src/developer/web-api/overview.md
+++ b/src/developer/web-api/overview.md
@@ -594,14 +594,23 @@ set:
 }
 ```
 
-To remove a custom label, set `label` to an empty string:
+To remove a custom label, set `label` to `null`:
 
 ```json
 {
   "name": "FinancialFeb",
-  "label": ""
+  "label": null
 }
 ```
+
+An empty string is accepted as well, and also stops the custom label from
+being displayed. Note that it is stored as given, so `label` is then
+returned as `""` rather than `null`, while `displayLabel` is `null` in both
+cases. Sending `null` is therefore the way to restore a period type to its
+original, unlabelled state.
+
+Because the label is taken from the request body as it is given, a request
+which leaves `label` out entirely also clears it.
 
 A request with a `name` which does not match an existing period type is
 rejected with `400 Bad Request` and the message *"FinancialFeb does not


### PR DESCRIPTION
Documents the `label` / `displayLabel` support on `PeriodType` added in 2.43, following up on https://github.com/dhis2/dhis2-releases/pull/261.

Adds a `Period types` subsection to the Web API introduction chapter (`src/developer/web-api/overview.md`), inside the existing *Date and period format* section and just after the period-format table, since that is where period types are already described. Covers `GET /api/periodTypes` with a property table marking `label` as the only writable field, plus a `Custom period type labels` subsection with the `PUT` request, the success response, the verify response, and clearing a label with an empty string.

Three details were checked against `dhis2-core` rather than taken from the release note, and differ from it:

- The release note's example body includes all fields (`isoDuration`, `frequencyOrder`, and so on). `PeriodTypeController.putPeriodType` only reads `getName()` and `getLabel()`, so everything else is silently ignored. The docs show `name` + `label` only.
- An unknown `name` returns `400 Bad Request` with the message `"<name> does not exist."` — `DefaultPeriodService.updatePeriodTypeLabel` throws `IllegalArgumentException`, which `CrudControllerAdvice` maps to `badRequest`. The status was not stated anywhere.
- `displayLabel` is `null`, not `displayName`, when no label is set — `PeriodType.getDisplayLabel()` returns `label` directly (with a `TODO` for the real implementation). The section therefore tells clients to render `displayLabel` and fall back to `displayName`, so apps adopting `displayLabel` now do not show blanks.

Also documents the `ALL` authority requirement (`@RequiresAuthority(anyOf = ALL)`).

Targets `master` only. If the 2.43 docs should carry it as well, that is a cherry-pick onto the `2.43` branch.

AI Assisted
